### PR TITLE
Once more unto the base(lining)

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -401,7 +401,7 @@ int DAQController::FitBaselines(std::vector<std::shared_ptr<V1724>> &digis,
   std::map<int, vector<vector<double>>> bl_per_channel;
   std::map<int, vector<int>> diff;
   std::map<int, std::map<std::string, vector<double>>> cal_values;
-  std::map<int, vector<int>> current_step;
+  std::map<int, vector<unsigned>> current_step;
 
   for (auto digi : digis) { // alloc ALL the things!
     bid = digi->bid();
@@ -500,8 +500,6 @@ int DAQController::FitBaselines(std::vector<std::shared_ptr<V1724>> &digis,
       for (auto& p : words_read) if ((0 <= p.second) && (p.second <= 16))
         fLog->Entry(MongoLog::Local, "Board %i undersized readout (%i)",
             p.first, p.second);
-      step--;
-      steps_repeated++;
       continue;
     }
 
@@ -560,9 +558,9 @@ int DAQController::FitBaselines(std::vector<std::shared_ptr<V1724>> &digis,
             bl_per_channel[bid][ch][step] = baseline;
             current_step[bid][ch]++;
 
-            if (current_step[bid][ch] < DAQ_cal_points.size()) {
+            if (current_step[bid][ch] < DAC_cal_points.size()) {
               continue;
-            } else if (current_step[bid][ch] == DAQ_cal_points.size()) {
+            } else if (current_step[bid][ch] == DAC_cal_points.size()) {
               // calibration constants
               B = C = D = E = F = 0;
               for (unsigned i = 0; i < DAC_cal_points.size(); i++) {

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -559,6 +559,7 @@ int DAQController::FitBaselines(std::vector<std::shared_ptr<V1724>> &digis,
             current_step[bid][ch]++;
 
             if (current_step[bid][ch] < DAC_cal_points.size()) {
+              done &= false;
               continue;
             } else if (current_step[bid][ch] == DAC_cal_points.size()) {
               // calibration constants
@@ -573,6 +574,7 @@ int DAQController::FitBaselines(std::vector<std::shared_ptr<V1724>> &digis,
               cal_values[bid]["slope"][ch] = slope = (C*D - E*F)/(B*C - F*F);
               cal_values[bid]["yint"][ch] = yint = (B*E - D*F)/(B*C - F*F);
               dac_values[bid][ch] = (target_baseline-yint)/slope;
+              done &= false;
             } else {
               // iterate
               if (channel_finished[bid][ch] >= convergence_threshold) {

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -410,7 +410,7 @@ int DAQController::FitBaselines(std::vector<std::shared_ptr<V1724>> &digis,
     channel_finished[bid] = vector<int>(ch_this_digi, 0);
     bl_per_channel[bid] = vector<vector<double>>(ch_this_digi, vector<double>(max_steps,0));
     diff[bid] = vector<int>(ch_this_digi, 0);
-    current_step[bid] = vector<int>(ch_this_digi, 0);
+    current_step[bid] = vector<unsigned>(ch_this_digi, 0);
     cal_values[bid] = std::map<std::string, vector<double>>(
         {{"slope", vector<double>(ch_this_digi)},
         {"yint", vector<double>(ch_this_digi)}});

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -332,13 +332,13 @@ void DAQController::StatusUpdate(mongocxx::collection* collection) {
 void DAQController::InitLink(std::vector<std::shared_ptr<V1724>>& digis,
     std::map<int, std::vector<uint16_t>>& dac_values, int& ret) {
   std::string BL_MODE = fOptions->GetString("baseline_dac_mode", "fixed");
-  int nominal_baseline = fOptions->GetInt("baseline_value", 16000);
   int nominal_dac = fOptions->GetInt("baseline_fixed_value", 4000);
   if (BL_MODE == "fit") {
-    if ((ret = FitBaselines(digis, dac_values, nominal_baseline))) {
+    if ((ret = FitBaselines(digis, dac_values)) < 0) {
       fLog->Entry(MongoLog::Warning, "Errors during baseline fitting");
       return;
-    }
+    } else if (ret > 0)
+      fLog->Entry(MongoLog::Warning, "Baselines didn't converge but we're going ahead");
   }
 
   for(auto& digi : digis){
@@ -352,19 +352,9 @@ void DAQController::InitLink(std::vector<std::shared_ptr<V1724>>& digis,
       fLog->Entry(MongoLog::Local, "Board %i using cached baselines", bid);
     } else if(BL_MODE == "fixed"){
       fLog->Entry(MongoLog::Local, "Loading fixed baselines with value 0x%04x", nominal_dac);
-      dac_values[bid] = std::vector<uint16_t>(digi->GetNumChannels(), nominal_dac);
+      dac_values[bid].assign(digi->GetNumChannels(), nominal_dac);
     } else {
       fLog->Entry(MongoLog::Warning, "Received unknown baseline mode '%s', valid options are \"fit\", \"cached\", and \"fixed\"", BL_MODE.c_str());
-      ret = -1;
-      return;
-    }
-
-    if(success==-2){
-      fLog->Entry(MongoLog::Warning, "Board %i Baselines failed with digi error");
-      ret = -2;
-      return;
-    } else if(success!=0){
-      fLog->Entry(MongoLog::Warning, "Board %i failed baselines with timeout", digi->bid());
       ret = -1;
       return;
     }
@@ -391,17 +381,17 @@ void DAQController::InitLink(std::vector<std::shared_ptr<V1724>>& digis,
 }
 
 int DAQController::FitBaselines(std::vector<std::shared_ptr<V1724>> &digis,
-    std::map<int, std::vector<u_int16_t>> &dac_values, int target_baseline) {
+    std::map<int, std::vector<u_int16_t>> &dac_values) {
   using std::vector;
   using namespace std::chrono_literals;
-  int max_iter = fOptions->GetInt("baseline_max_iterations", 2);
   unsigned ch_this_digi(0), max_steps = fOptions->GetInt("baseline_max_steps", 20);
   int adjustment_threshold = fOptions->GetInt("baseline_adjustment_threshold", 10);
   int convergence_threshold = fOptions->GetInt("baseline_convergence_threshold", 3);
   int min_adjustment = fOptions->GetInt("baseline_min_adjustment", 0xA);
   int rebin_factor = fOptions->GetInt("baseline_rebin_log2", 1); // log base 2
   int bins_around_max = fOptions->GetInt("baseline_bins_around_max", 3);
-  int steps_repeated(0), max_repeated_steps(10), bid(0);
+  int target_baseline = fOptions->GetInt("baseline_value", 16000);
+  int bid(0);
   int triggers_per_step = fOptions->GetInt("baseline_triggers_per_step", 3);
   std::chrono::milliseconds ms_between_triggers(fOptions->GetInt("baseline_ms_between_triggers", 10));
   vector<long> DAC_cal_points = {60000, 30000, 6000}; // arithmetic overflow
@@ -411,6 +401,7 @@ int DAQController::FitBaselines(std::vector<std::shared_ptr<V1724>> &digis,
   std::map<int, vector<vector<double>>> bl_per_channel;
   std::map<int, vector<int>> diff;
   std::map<int, std::map<std::string, vector<double>>> cal_values;
+  std::map<int, vector<int>> current_step;
 
   for (auto digi : digis) { // alloc ALL the things!
     bid = digi->bid();
@@ -419,9 +410,13 @@ int DAQController::FitBaselines(std::vector<std::shared_ptr<V1724>> &digis,
     channel_finished[bid] = vector<int>(ch_this_digi, 0);
     bl_per_channel[bid] = vector<vector<double>>(ch_this_digi, vector<double>(max_steps,0));
     diff[bid] = vector<int>(ch_this_digi, 0);
+    current_step[bid] = vector<int>(ch_this_digi, 0);
+    cal_values[bid] = std::map<std::string, vector<double>>(
+        {{"slope", vector<double>(ch_this_digi)},
+        {"yint", vector<double>(ch_this_digi)}});
   }
 
-  bool done(false), redo_iter(false), fail(false), calibrate(true);
+  bool done(true), fail(false);
   int counts_total(0), counts_around_max(0);
   double B,C,D,E,F, slope, yint, baseline;
   double fraction_around_max = fOptions->GetDouble("baseline_fraction_around_max", 0.8);
@@ -429,247 +424,187 @@ int DAQController::FitBaselines(std::vector<std::shared_ptr<V1724>> &digis,
   u_int16_t val0, val1;
   int channels_in_event;
 
-  for (int iter = 0; iter < max_iter; iter++) {
-    if (done || fail) break;
-    for (auto& vv : bl_per_channel) // vv = pair(int, vector<vector<double>>)
-      for (auto& v : vv.second) // v = vector<double>
-        v.assign(v.size(), 0);
-    for (auto& v : channel_finished) v.second.assign(v.second.size(), 0);
-    steps_repeated = 0;
-    fLog->Entry(MongoLog::Local, "Beginning baseline iteration %i/%i", iter, max_iter);
-
-    for (unsigned step = 0; step < max_steps; step++) {
-      fLog->Entry(MongoLog::Local, "Beginning baseline step %i/%i", step, max_steps);
-      if (std::all_of(channel_finished.begin(), channel_finished.end(),
-            [&](auto& p) {
-              return std::all_of(p.second.begin(), p.second.end(), [=](int i)
-                  {return i >= convergence_threshold;});})) {
-        fLog->Entry(MongoLog::Local, "All boards on this link finished baselining");
-        done = true;
-        break;
-      }
-      if (steps_repeated >= max_repeated_steps) {
-        fLog->Entry(MongoLog::Debug, "Repeating a lot of steps here");
-        break;
-      }
-      // prep
-      if (step < DAC_cal_points.size()) {
-        if (!calibrate) continue;
-        for (auto d : digis)
-          dac_values[d->bid()].assign(d->GetNumChannels(), (int)DAC_cal_points[step]);
-      }
-      for (auto d : digis) {
-        if (d->LoadDAC(dac_values[d->bid()])) {
-          fLog->Entry(MongoLog::Warning, "Board %i failed to load DAC", d->bid());
-          return -2;
+  for (unsigned step = 0; step < max_steps; step++) {
+    fLog->Entry(MongoLog::Local, "Beginning baseline step %i/%i", step, max_steps);
+    done = true;
+    // prep
+    for (auto d : digis) {
+      for (unsigned ch = 0; ch < d->GetNumChannels(); ch++) {
+        if (current_step[d->bid()][ch] < DAC_cal_points.size()) {
+          dac_values[d->bid()][ch] = DAC_cal_points[current_step[d->bid()][ch]];
         }
       }
-      // "After writing, the user is recommended to wait for a few seconds before
-      // a new RUN to let the DAC output get stabilized" - CAEN documentation
-      std::this_thread::sleep_for(1s);
-      // sleep(2) seems unnecessary after preliminary testing
+    }
+    for (auto d : digis) {
+      if (d->LoadDAC(dac_values[d->bid()])) {
+        fLog->Entry(MongoLog::Warning, "Board %i failed to load DAC", d->bid());
+        return -2;
+      }
+    }
+    // "After writing, the user is recommended to wait for a few seconds before
+    // a new RUN to let the DAC output get stabilized" - CAEN documentation
+    std::this_thread::sleep_for(1s);
+    // sleep(2) seems unnecessary after preliminary testing
 
-      // start board
-      for (auto d : digis) {
-        if (d->EnsureReady(1000,1000))
-          d->SoftwareStart();
-        else
-          fail = true;
-      }
-      std::this_thread::sleep_for(5ms);
-      for (auto d : digis) {
-        if (!d->EnsureStarted(1000,1000)) {
-          d->AcquisitionStop();
-          fail = true;
-        }
-      }
-
-      // send triggers
-      for (int trig = 0; trig < triggers_per_step; trig++) {
-        for (auto d : digis) d->SWTrigger();
-        std::this_thread::sleep_for(ms_between_triggers);
-      }
-      // stop
-      for (auto d : digis) {
+    // start board
+    for (auto d : digis) {
+      if (d->EnsureReady(1000,1000))
+        d->SoftwareStart();
+      else
+        fail = true;
+    }
+    std::this_thread::sleep_for(5ms);
+    for (auto d : digis) {
+      if (!d->EnsureStarted(1000,1000)) {
         d->AcquisitionStop();
-        if (!d->EnsureStopped(1000,1000)) {
-          fail = true;
-        }
+        fail = true;
       }
-      if (fail) {
-        for (auto d : digis) d->AcquisitionStop();
-        fLog->Entry(MongoLog::Warning, "Error in baseline digi control");
-        return -2;
-      }
-      std::this_thread::sleep_for(1ms);
-
-      // readout
-      for (auto d : digis) {
-        words_read[d->bid()] = d->Read(buffers[d->bid()]);
-      }
-
-      // decode
-      if (std::any_of(words_read.begin(), words_read.end(),
-            [=](auto p) {return p.second < 0;})) {
-        for (auto d : digis) {
-          if (words_read[d->bid()] < 0)
-            fLog->Entry(MongoLog::Error, "Board %i has readout error in baselines",
-                d->bid());
-        }
-        return -2;
-      }
-      if (std::any_of(words_read.begin(), words_read.end(), [=](auto p) {
-            return (0 <= p.second) && (p.second <= 16);})) { // header-only readouts???
-        for (auto& p : words_read) if ((0 <= p.second) && (p.second <= 16))
-          fLog->Entry(MongoLog::Local, "Board %i undersized readout (%i)",
-              p.first, p.second);
-        step--;
-        steps_repeated++;
-        continue;
-      }
-
-      // analyze
-      for (auto d : digis) {
-        bid = d->bid();
-        auto it = buffers[bid]->buff.begin();
-        while (it < buffers[bid]->buff.end()) {
-          if ((*it)>>28 == 0xA) {
-            words = (*it)&0xFFFFFFF;
-            std::u32string_view sv(buffers[bid]->buff.data() + std::distance(buffers[bid]->buff.begin(), it), words);
-            std::tie(words_in_event, channel_mask, std::ignore, std::ignore) = d->UnpackEventHeader(sv);
-            if (words == 4) {
-              it += 4;
-              continue;
-            }
-            if (channel_mask == 0) { // should be impossible?
-              it += 4;
-              continue;
-            }
-            channels_in_event = std::bitset<16>(channel_mask).count();
-            it += words;
-            sv.remove_prefix(4);
-            for (unsigned ch = 0; ch < d->GetNumChannels(); ch++) {
-              if (!(channel_mask & (1 << ch))) continue;
-              std::u32string_view wf;
-              std::tie(std::ignore, words, std::ignore, wf) = d->UnpackChannelHeader(sv,
-                  0, 0, 0, words, channels_in_event);
-              vector<int> hist(0x4000, 0);
-              for (auto w : wf) {
-                val0 = w&0x3FFF;
-                val1 = (w>>16)&0x3FFF;
-                if (val0*val1 == 0) continue;
-                hist[val0 >> rebin_factor]++;
-                hist[val1 >> rebin_factor]++;
-              }
-              sv.remove_prefix(words);
-              auto max_it = std::max_element(hist.begin(), hist.end());
-              auto max_start = std::max(max_it - bins_around_max, hist.begin());
-              auto max_end = std::min(max_it + bins_around_max+1, hist.end());
-              counts_total = std::accumulate(hist.begin(), hist.end(), 0);
-              counts_around_max = std::accumulate(max_start, max_end, 0);
-              if (counts_around_max < fraction_around_max*counts_total) {
-                fLog->Entry(MongoLog::Local,
-                    "Bd %i ch %i: %i out of %i counts around max %i",
-                    bid, ch, counts_around_max, counts_total,
-                    std::distance(hist.begin(), max_it)<<rebin_factor);
-                redo_iter = true;
-              }
-              if (counts_total < 1.5*words) {//25% zeros
-                redo_iter = true;
-                fLog->Entry(MongoLog::Local, "Bd %i ch %i too many skipped samples", bid, ch);
-              }
-              vector<int> bin_ids(std::distance(max_start, max_end), 0);
-              std::iota(bin_ids.begin(), bin_ids.end(), std::distance(hist.begin(), max_start));
-              baseline = 0;
-              // calculated weighted average
-              baseline = std::inner_product(max_start, max_end, bin_ids.begin(), 0) << rebin_factor;
-              baseline /= counts_around_max;
-              bl_per_channel[bid][ch][step] = baseline;
-            } // for each channel
-
-          } else { // if header
-            it++;
-          }
-        } // end of while in buffer
-      } // process per digi
-      if (redo_iter) {
-        redo_iter = false;
-        step--;
-        steps_repeated++;
-        continue;
-      }
-      if (step+1 < DAC_cal_points.size()) continue;
-      if (step+1 == DAC_cal_points.size() && calibrate) {
-        // ****************************
-        // Determine calibration values
-        // ****************************
-        for (auto d : digis) {
-          bid = d->bid();
-          cal_values[bid] = std::map<std::string, vector<double>>(
-              {{"slope", vector<double>(d->GetNumChannels())},
-               {"yint", vector<double>(d->GetNumChannels())}});
-          for (unsigned ch = 0; ch < d->GetNumChannels(); ch++) {
-            B = C = D = E = F = 0;
-            for (unsigned i = 0; i < DAC_cal_points.size(); i++) {
-              B += DAC_cal_points[i]*DAC_cal_points[i];
-              C += 1;
-              D += DAC_cal_points[i]*bl_per_channel[bid][ch][i];
-              E += bl_per_channel[bid][ch][i];
-              F += DAC_cal_points[i];
-            }
-            cal_values[bid]["slope"][ch] = slope = (C*D - E*F)/(B*C - F*F);
-            cal_values[bid]["yint"][ch] = yint = (B*E - D*F)/(B*C - F*F);
-            dac_values[bid][ch] = (target_baseline-yint)/slope;
-          }
-        }
-        calibrate = false;
-      } else {
-        // ******************
-        // Do fitting process
-        // ******************
-        for (auto d : digis) {
-          bid = d->bid();
-          for (unsigned ch = 0; ch < d->GetNumChannels(); ch++) {
-            if (channel_finished[bid][ch] >= convergence_threshold) continue;
-
-            float off_by = target_baseline - bl_per_channel[bid][ch][step];
-            if (abs(off_by) < adjustment_threshold) {
-              channel_finished[bid][ch]++;
-              continue;
-            }
-            channel_finished[bid][ch] = std::max(0, channel_finished[bid][ch]-1);
-            int adjustment = off_by * cal_values[bid]["slope"][ch];
-            if (abs(adjustment) < min_adjustment)
-              adjustment = std::copysign(min_adjustment, adjustment);
-            dac_values[bid][ch] += adjustment;
-          } // for channels
-        } // for digis
-      } // fit/calibrate
-      for (auto d : digis)
-        d->ClampDACValues(dac_values[d->bid()], cal_values[d->bid()]);
-
-    } // end steps
-    if (std::all_of(channel_finished.begin(), channel_finished.end(),
-          [&](auto& p){return std::all_of(p.second.begin(), p.second.end(), [=](int i){
-            return i >= convergence_threshold;});})) {
-      fLog->Entry(MongoLog::Local, "All baselines for boards on this link converged");
-      break;
     }
-  } // end iterations
-  if (fail) return -2;
-  if (std::any_of(channel_finished.begin(), channel_finished.end(),
-      [&](auto& p){return std::any_of(p.second.begin(), p.second.end(), [=](int i){
-        return i < convergence_threshold;});})) {
-    fLog->Entry(MongoLog::Warning, "Couldn't baseline properly!");
-    return -1;
-  }
-  for (auto d : digis) {
-    for (unsigned ch = 0; ch < d->GetNumChannels(); ch++) {
+
+    // send triggers
+    for (int trig = 0; trig < triggers_per_step; trig++) {
+      for (auto d : digis) d->SWTrigger();
+      std::this_thread::sleep_for(ms_between_triggers);
+    }
+    // stop
+    for (auto d : digis) {
+      d->AcquisitionStop();
+      if (!d->EnsureStopped(1000,1000)) {
+        fail = true;
+      }
+    }
+    if (fail) {
+      for (auto d : digis) d->AcquisitionStop();
+      fLog->Entry(MongoLog::Warning, "Error in baseline digi control");
+      return -2;
+    }
+    std::this_thread::sleep_for(1ms);
+
+    // readout
+    for (auto d : digis) {
+      words_read[d->bid()] = d->Read(buffers[d->bid()]);
+    }
+
+    // decode
+    if (std::any_of(words_read.begin(), words_read.end(),
+          [=](auto p) {return p.second < 0;})) {
+      for (auto d : digis) {
+        if (words_read[d->bid()] < 0)
+          fLog->Entry(MongoLog::Error, "Board %i has readout error in baselines",
+              d->bid());
+      }
+      return -2;
+    }
+    if (std::any_of(words_read.begin(), words_read.end(), [=](auto p) {
+          return (0 <= p.second) && (p.second <= 16);})) { // header-only readouts???
+      for (auto& p : words_read) if ((0 <= p.second) && (p.second <= 16))
+        fLog->Entry(MongoLog::Local, "Board %i undersized readout (%i)",
+            p.first, p.second);
+      step--;
+      steps_repeated++;
+      continue;
+    }
+
+    // analyze
+    for (auto d : digis) {
       bid = d->bid();
-      fLog->Entry(MongoLog::Local, "Bd %i ch %i exp %x act %x", bid, ch,
-        (target_baseline-cal_values[bid]["yint"][ch])/cal_values[bid]["slope"][ch],
-        dac_values[bid][ch]);
-    }
-  }
-  return 0;
+      auto it = buffers[bid]->buff.begin();
+      while (it < buffers[bid]->buff.end()) {
+        if ((*it)>>28 == 0xA) {
+          words = (*it)&0xFFFFFFF;
+          std::u32string_view sv(buffers[bid]->buff.data() + std::distance(buffers[bid]->buff.begin(), it), words);
+          std::tie(words_in_event, channel_mask, std::ignore, std::ignore) = d->UnpackEventHeader(sv);
+          if (words == 4) {
+            it += 4;
+            continue;
+          }
+          if (channel_mask == 0) { // should be impossible?
+            it += 4;
+            continue;
+          }
+          channels_in_event = std::bitset<16>(channel_mask).count();
+          it += words;
+          sv.remove_prefix(4);
+          for (unsigned ch = 0; ch < d->GetNumChannels(); ch++) {
+            if (!(channel_mask & (1 << ch))) continue;
+            std::u32string_view wf;
+            std::tie(std::ignore, words, std::ignore, wf) = d->UnpackChannelHeader(sv,
+                0, 0, 0, words, channels_in_event);
+            vector<int> hist(0x4000, 0);
+            for (auto w : wf) {
+              val0 = w&0x3FFF;
+              val1 = (w>>16)&0x3FFF;
+              if (val0*val1 == 0) continue;
+              hist[val0 >> rebin_factor]++;
+              hist[val1 >> rebin_factor]++;
+            }
+            sv.remove_prefix(words);
+            auto max_it = std::max_element(hist.begin(), hist.end());
+            auto max_start = std::max(max_it - bins_around_max, hist.begin());
+            auto max_end = std::min(max_it + bins_around_max+1, hist.end());
+            counts_total = std::accumulate(hist.begin(), hist.end(), 0);
+            counts_around_max = std::accumulate(max_start, max_end, 0);
+            if (counts_around_max < fraction_around_max*counts_total) {
+              fLog->Entry(MongoLog::Local,
+                  "Bd %i ch %i: %i out of %i counts around max %i",
+                  bid, ch, counts_around_max, counts_total,
+                  std::distance(hist.begin(), max_it)<<rebin_factor);
+              continue;
+            }
+            vector<int> bin_ids(std::distance(max_start, max_end), 0);
+            std::iota(bin_ids.begin(), bin_ids.end(), std::distance(hist.begin(), max_start));
+            baseline = 0;
+            // calculated weighted average
+            baseline = std::inner_product(max_start, max_end, bin_ids.begin(), 0) << rebin_factor;
+            baseline /= counts_around_max;
+            bl_per_channel[bid][ch][step] = baseline;
+            current_step[bid][ch]++;
+
+            if (current_step[bid][ch] < DAQ_cal_points.size()) {
+              continue;
+            } else if (current_step[bid][ch] == DAQ_cal_points.size()) {
+              // calibration constants
+              B = C = D = E = F = 0;
+              for (unsigned i = 0; i < DAC_cal_points.size(); i++) {
+                B += DAC_cal_points[i]*DAC_cal_points[i];
+                C += 1;
+                D += DAC_cal_points[i]*bl_per_channel[bid][ch][i];
+                E += bl_per_channel[bid][ch][i];
+                F += DAC_cal_points[i];
+              }
+              cal_values[bid]["slope"][ch] = slope = (C*D - E*F)/(B*C - F*F);
+              cal_values[bid]["yint"][ch] = yint = (B*E - D*F)/(B*C - F*F);
+              dac_values[bid][ch] = (target_baseline-yint)/slope;
+            } else {
+              // iterate
+              if (channel_finished[bid][ch] >= convergence_threshold) {
+                done &= true;
+                continue;
+              }
+
+              float off_by = target_baseline - bl_per_channel[bid][ch][step];
+              if (abs(off_by) < adjustment_threshold) {
+                channel_finished[bid][ch]++;
+                continue;
+              }
+              done &= false;
+              channel_finished[bid][ch] = std::max(0, channel_finished[bid][ch]-1);
+              int adjustment = off_by * cal_values[bid]["slope"][ch];
+              if (abs(adjustment) < min_adjustment)
+                adjustment = std::copysign(min_adjustment, adjustment);
+              dac_values[bid][ch] += adjustment;
+            }
+
+          } // for each channel
+
+        } else { // if header
+          it++;
+        }
+      } // end of while in buffer
+      d->ClampDACValues(dac_values[bid], cal_values[bid]);
+    } // process per digi
+
+    if (done) return 0;
+  } // end steps
+  return 1;
 }

--- a/DAQController.hh
+++ b/DAQController.hh
@@ -43,7 +43,7 @@ private:
   int OpenThreads();
   void CloseThreads();
   void InitLink(std::vector<std::shared_ptr<V1724>>&, std::map<int, std::vector<uint16_t>>&, int&);
-  int FitBaselines(std::vector<std::shared_ptr<V1724>>&, std::map<int, std::vector<uint16_t>>&, int);
+  int FitBaselines(std::vector<std::shared_ptr<V1724>>&, std::map<int, std::vector<uint16_t>>&);
 
   std::vector<std::unique_ptr<StraxFormatter>> fFormatters;
   std::vector<std::thread> fProcessingThreads;

--- a/Options.cc
+++ b/Options.cc
@@ -13,7 +13,8 @@
 Options::Options(std::shared_ptr<MongoLog>& log, std::string options_name, std::string hostname,
           mongocxx::collection* opts_collection, std::shared_ptr<mongocxx::pool>& pool,
           std::string dbname, std::string override_opts) : 
-    fLog(log), fHostname(hostname), fPool(pool), fClient(pool->acquire()) {
+    fLog(log), fHostname(hostname), fPool(pool), fClient(pool->acquire()), 
+    fDAC_cache(bsoncxx::document::view()) {
   bson_value = NULL;
   if(Load(options_name, opts_collection, override_opts)!=0)
     throw std::runtime_error("Can't initialize options class");

--- a/Options.hh
+++ b/Options.hh
@@ -102,6 +102,7 @@ private:
   mongocxx::pool::entry fClient; // yes
   mongocxx::database fDB;
   mongocxx::collection fDAC_collection;
+  bsoncxx::document::value fDAC_cache;
 };
 
 #endif


### PR DESCRIPTION
A major issue with the baseline routine v2 was that if one channel had noise issues, all other channels on that link were prevented from progressing through the baseline sequence. This PR makes the baselining much more independent as channels are allowed to progress separately, and one noisy channel means only that channel fails, not the others as well.

Also, some changes to the caching of baseline values, they are now loaded in the Options constructor if necessary.