### PR TITLE
Adds option to disable logfile removal

### DIFF
--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -66,6 +66,7 @@ int MongoLog::RotateLogFile() {
     return -1;
   }
   fOutfile << FormatTime(&today) << " [INIT]: logfile initialized\n";
+  if (fDeleteAfterDays == 0) return 0;
   fToday = Today(&today);
   std::vector<int> days_per_month = {31,28,31,30,31,30,31,31,30,31,30,31};
   if (today.tm_year%4 == 0) days_per_month[1] += 1; // the edge-case is SEP

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -66,8 +66,8 @@ int MongoLog::RotateLogFile() {
     return -1;
   }
   fOutfile << FormatTime(&today) << " [INIT]: logfile initialized\n";
-  if (fDeleteAfterDays == 0) return 0;
   fToday = Today(&today);
+  if (fDeleteAfterDays == 0) return 0;
   std::vector<int> days_per_month = {31,28,31,30,31,30,31,31,30,31,30,31};
   if (today.tm_year%4 == 0) days_per_month[1] += 1; // the edge-case is SEP
   struct tm last_week = today;

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -256,16 +256,16 @@ class MongoConnect():
             for doc in self.collections['incoming_commands'].aggregate([
                 {'$sort': {'_id': -1}},
                 {'$group': {
-                    '_id': {'$concat': ['$detector', '.', '$field']},
+                    '_id': '$key',
                     'value': {'$first': '$value'},
                     'user': {'$first': '$user'},
                     'time': {'$first': '$time'},
                     'detector': {'$first': '$detector'},
-                    'key': {'$first': '$field'}
+                    'field': {'$first': '$field'}
                     }},
                 {'$group': {
                     '_id': '$detector',
-                    'keys': {'$push': '$key'},
+                    'fields': {'$push': '$field'},
                     'values': {'$push': '$value'},
                     'users': {'$push': '$user'},
                     'times': {'$push': '$time'}
@@ -273,7 +273,7 @@ class MongoConnect():
                 {'$project': {
                     'detector': '$_id',
                     '_id': 0,
-                    'state': {'$arrayToObject': {'$zip': {'inputs': ['$keys', '$values']}}},
+                    'state': {'$arrayToObject': {'$zip': {'inputs': ['$fields', '$values']}}},
                     'user': {'$arrayElemAt': ['$users', {'$indexOfArray': ['$times', {'$max': '$times'}]}]}
                     }}
                 ]):

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -21,7 +21,7 @@ class SignalHandler(object):
         self.event.set()
 
 class LogHandler(logging.Handler):
-    def __init__(self, logdir='/live_data/redax_logs/', retention=7):
+    def __init__(self, logdir='/live_data/redax_logs/', retention=0):
         logging.Handler.__init__(self)
         self.today = datetime.date.today()
         self.logdir = logdir
@@ -53,7 +53,9 @@ class LogHandler(logging.Handler):
     def Rotate(self, when):
         if hasattr(self, 'f'):
             self.f.close()
-        self.f = open(self.FullFilename(when), 'w')
+        self.f = open(self.FullFilename(when), 'a')
+        if self.retention == 0:
+            return
         last_file = when - datetime.timedelta(days=self.retention)
         if os.path.exists(self.FullFilename(last_file)):
             os.remove(self.FullFilename(last_file))

--- a/main.cc
+++ b/main.cc
@@ -75,7 +75,7 @@ int main(int argc, char** argv){
   std::string current_run_id="none", log_dir = "";
   std::string dbname = "daq", suri = "", sid = "";
   bool reader = false, cc = false;
-  int log_retention = 7; // days
+  int log_retention = 0; // days, 0 = someone else's problem
   int c(0), opt_index, delay(0);
   struct option longopts[] = {
     {"id", required_argument, 0, c++},


### PR DESCRIPTION
This supports https://github.com/XENONnT/daqnt/pull/8, which is a dedicated script to handle logfile removal. This also fixes a bug in the dispatcher logging where it opened files `open(fn, 'w')` instead of `open(fn, 'a')`.