### PR TITLE
Adds a 1s delay between START commands

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -100,10 +100,7 @@ int DAQController::Arm(std::shared_ptr<Options>& options){
 
   for(auto& link : fDigitizers ) {
     for(auto& digi : link.second){
-      if(fOptions->GetInt("run_start", 0) == 1)
-	digi->SINStart();
-      else
-	digi->AcquisitionStop();
+      digi->AcquisitionStop();
     }
   }
   fCounter = 0;
@@ -141,6 +138,10 @@ int DAQController::Start(){
 	}
       }
     }
+  } else {
+    for (auto& link : fDigitizers)
+      for (auto& digi : link.second)
+        digi->SINStart();
   }
   fStatus = DAXHelpers::Running;
   return 0;

--- a/V1724.cc
+++ b/V1724.cc
@@ -98,6 +98,8 @@ int V1724::Init(int link, int crate, std::shared_ptr<Options>& opts) {
 
 int V1724::SINStart(){
   fLastClockTime = std::chrono::high_resolution_clock::now();
+  fRolloverCounter = 0;
+  fLastClock = 0;
   return WriteRegister(fAqCtrlRegister,0x105);
 }
 int V1724::SoftwareStart(){

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -368,7 +368,7 @@ class MongoConnect():
         '''
         self.log.info("Updating run %i with end time"%number)
         try:
-            time.sleep(2) # this number depends on the delay between CC and reader stop
+            time.sleep(0.5) # this number depends on the CC command polling time
             endtime = self.GetAckTime(detector, 'stop')
             if endtime is None:
                 endtime = datetime.datetime.utcnow()-datetime.timedelta(seconds=1)
@@ -400,13 +400,11 @@ class MongoConnect():
         Send this command to these hosts. If delay is set then wait that amount of time
         '''
         number = None
-        n_id = None
         try:
             if command == 'arm':
                 number = self.GetNextRunNumber()
                 if number == -1:
                     return -1
-                n_id = '%06i' % number
                 self.latest_status[detector]['number'] = number
             doc_base = {
                 "command": command,
@@ -510,7 +508,8 @@ class MongoConnect():
             'detectors': detectors,
             'user': goal_state[detector]['user'],
             'mode': goal_state[detector]['mode'],
-            #'bootstrax': {'state': None}, # SOON (TM)
+            'bootstrax': {'state': None},
+            'end': None
         }
 
         # If there's a source add the source. Also add the complete ini file.
@@ -540,8 +539,8 @@ class MongoConnect():
             start_time = self.GetAckTime(detector, 'start')
             if start_time is None:
                 start_time = datetime.datetime.utcnow()-datetime.timedelta(seconds=2)
+                run_doc['tags'] = [{'name': 'messy', 'user': 'daq', 'date': start_time}]
             run_doc['start'] = start_time
-            run_doc['end'] = None
 
             self.collections['run'].insert_one(run_doc)
         except Exception as e:


### PR DESCRIPTION
Currently the boards enter the READY state when that reader finishes its arming sequence. If one host takes longer to arm then boards on the other hosts sit in this state for a while. Normally this isn't an issue but we've seen situations where these boards sometimes briefly flare to life for unknown reasons, which wrecks the rollover logic for that run. This PR changes how the end of the arming sequence behaves. Boards are now set to "idle" after arming, only being placed in a readied state on the receipt of the START command. The crate controller now receives the START command one second after the readers to allow for enough time for all boards to enter READY but hopefully limiting time for potential S-IN noise to cause shenanigans.