### PR TITLE
Builds version information into the executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SHELL	= /bin/bash -O extglob -c
 CC	= g++
 CXX	= g++
-BUILD_DATE = $(shell date --rfc-3339=seconds)
-BUILD_BRANCH = $(shell git branch | awk '/\*/ {print $2}')
-CFLAGS	= -Wall -Wextra -pedantic -pedantic-errors -g -DLINUX -DREDAX_BUILD_BRANCH=$(BUILD_BRANCH) -DREDAX_BUILD_DATE=$(BUILD_DATE) -std=c++17 -pthread $(shell pkg-config --cflags libmongocxx)
+BUILD_DATE = "$(shell date -I)"
+BUILD_BRANCH = "$(shell git branch | awk '/\*/ {print $$2}')"
+CFLAGS	= -Wall -Wextra -pedantic -pedantic-errors -g -DLINUX -DREDAX_BUILD_BRANCH='$(BUILD_BRANCH)' -DREDAX_BUILD_DATE='$(BUILD_DATE)' -std=c++17 -pthread $(shell pkg-config --cflags libmongocxx)
 CPPFLAGS := $(CFLAGS)
 IS_READER0 := false
 ifeq "$(shell hostname)" "reader0"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 SHELL	= /bin/bash -O extglob -c
 CC	= g++
 CXX	= g++
-CFLAGS	= -Wall -Wextra -pedantic -pedantic-errors -g -DLINUX -std=c++17 -pthread $(shell pkg-config --cflags libmongocxx)
+BUILD_DATE = $(shell date --rfc-3339=seconds)
+BUILD_BRANCH = $(shell git branch | awk '/\*/ {print $2}')
+CFLAGS	= -Wall -Wextra -pedantic -pedantic-errors -g -DLINUX -DREDAX_BUILD_BRANCH=$(BUILD_BRANCH) -DREDAX_BUILD_DATE=$(BUILD_DATE) -std=c++17 -pthread $(shell pkg-config --cflags libmongocxx)
 CPPFLAGS := $(CFLAGS)
 IS_READER0 := false
 ifeq "$(shell hostname)" "reader0"

--- a/main.cc
+++ b/main.cc
@@ -20,6 +20,14 @@
 #include <mongocxx/client.hpp>
 #include <mongocxx/pool.hpp>
 
+#ifndef REDAX_BUILD_BRANCH
+#define REDAX_BUILD_BRANCH "unknown"
+#endif
+
+#ifndef REDAX_BUILD_DATE
+#define REDAX_BUILD_DATE "unknown"
+#endif
+
 std::atomic_bool b_run = true;
 std::string hostname = "";
 
@@ -124,6 +132,7 @@ int main(int argc, char** argv){
   gethostname(chostname, HOST_NAME_MAX);
   hostname=chostname;
   hostname+= (reader ? "_reader_" : "_controller_") + sid;
+  std::cout << "Welcome to redax, this is build " << REDAX_BUILD_BRANCH << " compiled on " << REDAX_BUILD_DATE << "\n";
   std::cout<<"Reader starting with ID: "<<hostname<<std::endl;
 
   // MongoDB Connectivity for control database. Bonus for later:


### PR DESCRIPTION
It's really useful to have the executable contain some information about when it was built and from which branch. This PR adds this via some Make magic.