### PR TITLE
Simulate errors and crashes

### DIFF
--- a/f1724.cc
+++ b/f1724.cc
@@ -59,6 +59,7 @@ f1724::f1724(std::shared_ptr<MongoLog>& log, std::shared_ptr<Options>& opts, int
   fSimulateCrashes = true;
   fFailProb = 1e-4;
   fCrashProb = 1e-6;
+  fError = 0;
 }
 
 f1724::~f1724() {
@@ -377,6 +378,7 @@ void f1724::ConvertToDigiFormat(const vector<vector<double>>& wf, int mask, long
   word = mask;
   if (fSimulateCrashes && ((fail = fFlatDist(fGen)) < fFailProb)) {
     word |= (1 << 26); // set the FAIL bit
+    fError = 1;
     if (fail < fCrashProb)
       throw std::runtime_error("Oops, I crashed");
   }

--- a/f1724.hh
+++ b/f1724.hh
@@ -27,7 +27,7 @@ public:
   virtual bool EnsureReady(int, int) {return sRun || sReady;}
   virtual bool EnsureStarted(int, int) {return sRun == true;}
   virtual bool EnsureStopped(int, int) {return sRun == false;}
-  virtual int CheckErrors() {return 0;}
+  virtual int CheckErrors() {return fError ? 1 : 0;}
   virtual uint32_t GetAcquisitionStatus();
 
 protected:

--- a/f1724.hh
+++ b/f1724.hh
@@ -93,6 +93,8 @@ protected:
   std::thread fGeneratorThread;
 
   bool fSeenUnder5, fSeenOver15;
+  bool fSimluateCrashes;
+  double fFailProb, fCrashProb;
 };
 
 #endif // _F1724_HH_ defined

--- a/f1724.hh
+++ b/f1724.hh
@@ -93,7 +93,7 @@ protected:
   std::thread fGeneratorThread;
 
   bool fSeenUnder5, fSeenOver15;
-  bool fSimluateCrashes;
+  bool fSimulateCrashes;
   double fFailProb, fCrashProb;
 };
 


### PR DESCRIPTION
Fax is supposed to be a full hardware-less test of the V1724. This should include the occasional crash. This PR adds a small chance (1e-4) for each f1724 to have an error when it generates a waveform, and a smaller (1e-6) chance for that redax to just crash. At some point these chances will be configurable.