### PR TITLE
Logging structure

### DIFF
--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -149,6 +149,6 @@ fs::path MongoLog_nT::OutputDirectory(struct tm* date) {
   return fOutputDir / std::to_string(date->tm_year+1900) / std::string(temp);
 }
 
-std::string MongoLog_nT::LogFileName(struct tm* date) {
+std::string MongoLog_nT::LogFileName(struct tm*) {
   return fHostname + ".log";
 }

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -63,7 +63,7 @@ int MongoLog::RotateLogFile() {
   auto today = *std::gmtime(&t);
   auto filename = LogFileName(&today);
   std::cout<<"Logging to " << filename << std::endl;
-  auto pp = filname.parent_path();
+  auto pp = filename.parent_path();
   if (!fs::exists(pp) && !fs::create_directories(pp)) {
     std::cout << "Could not create output directories for logging!" << std::endl;
     return -1;
@@ -139,10 +139,6 @@ int MongoLog::Entry(int priority, std::string message, ...){
   return 0;
 }
 
-
-MongoLog_nT::MongoLog_nT(std::shared_ptr<mongocxx::pool>& pool, std::string dbname, std::string host) : MongoLog(0, pool, dbname, "/live_data/redax_logs", host) {}
-
-MongoLog_nT::~MongoLog_nT() {}
 
 fs::path MongoLog_nT::OutputDirectory(struct tm* date) {
   char temp[6];

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -64,7 +64,7 @@ int MongoLog::RotateLogFile() {
   if (fOutfile.is_open()) fOutfile.close();
   auto t = std::time(0);
   auto today = *std::gmtime(&t);
-  auto filename = LogFileName(&today);
+  auto filename = LogFilePath(&today);
   std::cout<<"Logging to " << filename << std::endl;
   auto pp = filename.parent_path();
   if (!fs::exists(pp) && !fs::create_directories(pp)) {

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -48,9 +48,12 @@ int MongoLog::Today(struct tm* date) {
   return (date->tm_year+1900)*10000 + (date->tm_mon+1)*100 + (date->tm_mday);
 }
 
-fs::path MongoLog::LogFileName(struct tm* date) {
-  std::string fname = std::to_string(Today(date)) + "_" + fHostname + ".log";
-  return OutputDirectory(date)/fname;
+std::string MongoLog::LogFileName(struct tm* date) {
+  return std::to_string(Today(date)) + "_" + fHostname + ".log";
+}
+
+fs::path MongoLog::LogFilePath(struct tm* date) {
+  return OutputDirectory(date)/LogFileName(date);
 }
 
 fs::path MongoLog::OutputDirectory(struct tm*) {
@@ -146,3 +149,6 @@ fs::path MongoLog_nT::OutputDirectory(struct tm* date) {
   return fOutputDir / std::to_string(date->tm_year+1900) / std::string(temp);
 }
 
+std::string MongoLog_nT::LogFileName(struct tm* date) {
+  return fHostname + ".log";
+}

--- a/MongoLog.hh
+++ b/MongoLog.hh
@@ -75,8 +75,10 @@ protected:
   int RotateLogFile();
   virtual std::string FormatTime(struct tm*);
   virtual int Today(struct tm*);
-  virtual std::experimental::filesystem::path LogFileName(struct tm*);
+  virtual std::string LogFileName(struct tm*);
   virtual std::experimental::filesystem::path OutputDirectory(struct tm*);
+  virtual std::experimental::filesystem::path LogFilePath(struct tm*);
+
 
   std::shared_ptr<mongocxx::pool> fPool;
   mongocxx::pool::entry fClient;
@@ -101,10 +103,11 @@ class MongoLog_nT : public MongoLog {
 public:
   // subclass to support the managed logging
   MongoLog_nT(std::shared_ptr<mongocxx::pool>& pool, std::string dbname, std::string host) :
-    MongoLog(0, pool, dbname, "/live_data/redax_logs", host) {}
+    MongoLog(0, pool, dbname, "/daq_common/logs", host) {}
   virtual ~MongoLog_nT() {}
 
 protected:
+  virtual std::string LogFileName(struct tm*);
   virtual std::experimental::filesystem::path OutputDirectory(struct tm*);
 };
 #endif

--- a/MongoLog.hh
+++ b/MongoLog.hh
@@ -59,10 +59,6 @@ public:
   MongoLog(int, std::shared_ptr<mongocxx::pool>&, std::string, std::string, std::string);
   ~MongoLog();
 
-  int  Initialize(std::string connection_string,
-		  std::string db, std::string collection,
-		  std::string host, bool debug=false);
-
   const static int Debug   = 0;  // Verbose output
   const static int Message = 1;  // Normal output
   const static int Warning = 2;  // Bad but minor operational impact
@@ -70,6 +66,7 @@ public:
   const static int Fatal   = 4;  // Program gonna die
   const static int Local   = -1; // Write to local (file) log only
 
+  virtual int Initialize() {return RotateLogFile();}
   int Entry(int priority, std::string, ...);
   void SetRunId(const int runid) {fRunId = runid;}
 
@@ -77,8 +74,9 @@ protected:
   void Flusher();
   std::string FormatTime(struct tm*);
   int Today(struct tm*);
-  virtual int RotateLogFile();
+  int RotateLogFile();
   virtual std::string LogFileName(struct tm*);
+  virtual std::experimental::filesystem::path OutputDirectory(struct tm*);
 
   std::shared_ptr<mongocxx::pool> fPool;
   mongocxx::pool::entry fClient;
@@ -106,7 +104,6 @@ public:
   virtual ~MongoLog_nT();
 
 protected:
-  virtual int RotateLogFile();
-  std::experimental::filesystem::path OutputDir(struct tm*);
+  virtual std::experimental::filesystem::path OutputDirectory(struct tm*);
 };
 #endif

--- a/MongoLog.hh
+++ b/MongoLog.hh
@@ -67,15 +67,15 @@ public:
   const static int Local   = -1; // Write to local (file) log only
 
   virtual int Initialize() {return RotateLogFile();}
-  int Entry(int priority, std::string, ...);
+  virtual int Entry(int priority, std::string, ...);
   void SetRunId(const int runid) {fRunId = runid;}
 
 protected:
   void Flusher();
-  std::string FormatTime(struct tm*);
-  int Today(struct tm*);
   int RotateLogFile();
-  virtual std::string LogFileName(struct tm*);
+  virtual std::string FormatTime(struct tm*);
+  virtual int Today(struct tm*);
+  virtual std::experimental::filesystem::path LogFileName(struct tm*);
   virtual std::experimental::filesystem::path OutputDirectory(struct tm*);
 
   std::shared_ptr<mongocxx::pool> fPool;
@@ -100,8 +100,9 @@ protected:
 class MongoLog_nT : public MongoLog {
 public:
   // subclass to support the managed logging
-  MongoLog_nT(std::shared_ptr<mongocxx::pool>&, std::string, std::string);
-  virtual ~MongoLog_nT();
+  MongoLog_nT(std::shared_ptr<mongocxx::pool>& pool, std::string dbname, std::string host) :
+    MongoLog(0, pool, dbname, "/live_data/redax_logs", host) {}
+  virtual ~MongoLog_nT() {}
 
 protected:
   virtual std::experimental::filesystem::path OutputDirectory(struct tm*);

--- a/main.cc
+++ b/main.cc
@@ -150,6 +150,10 @@ int main(int argc, char** argv){
     fLog = std::make_shared<MongoLog_nT>(pool, dbname, hostname);
   else
     fLog = std::make_shared<MongoLog>(log_retention, pool, dbname, log_dir, hostname);
+  if (fLog->Initialize()) {
+    std::cout<<"Could not initialize logs!\n";
+    exit(-1);
+  }
 
   //Options
   std::shared_ptr<Options> fOptions;


### PR DESCRIPTION
We wrote a whole logging module for the python parts of the nT DAQ (https://github.com/XENONnT/daqnt/pull/12), this is the matching extension for redax. Available by specifying `--log-dir=nT` at the command line.