### PR TITLE
Millisecond-precision logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 SHELL	= /bin/bash -O extglob -c
 CC	= g++
 CXX	= g++
-BUILD_DATE = "$(shell date -I)"
-BUILD_BRANCH = "$(shell git branch | awk '/\*/ {print $$2}')"
-CFLAGS	= -Wall -Wextra -pedantic -pedantic-errors -g -DLINUX -DREDAX_BUILD_BRANCH='$(BUILD_BRANCH)' -DREDAX_BUILD_DATE='$(BUILD_DATE)' -std=c++17 -pthread $(shell pkg-config --cflags libmongocxx)
+BUILD_BRANCH = "$(shell git log -n 1 --pretty=oneline | awk '{print $$1}')"
+CFLAGS	= -Wall -Wextra -pedantic -pedantic-errors -g -DLINUX -DREDAX_BUILD_COMMIT='$(BUILD_BRANCH)' -std=c++17 -pthread $(shell pkg-config --cflags libmongocxx)
 CPPFLAGS := $(CFLAGS)
 IS_READER0 := false
 ifeq "$(shell hostname)" "reader0"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 SHELL	= /bin/bash -O extglob -c
 CC	= g++
 CXX	= g++
-BUILD_BRANCH = "$(shell git log -n 1 --pretty=oneline | awk '{print $$1}')"
-CFLAGS	= -Wall -Wextra -pedantic -pedantic-errors -g -DLINUX -DREDAX_BUILD_COMMIT='$(BUILD_BRANCH)' -std=c++17 -pthread $(shell pkg-config --cflags libmongocxx)
+BUILD_COMMIT = "$(shell git log -n 1 --pretty=oneline | awk '{print $$1}')"
+CFLAGS	= -Wall -Wextra -pedantic -pedantic-errors -g -DLINUX -DREDAX_BUILD_COMMIT='$(BUILD_COMMIT)' -std=c++17 -pthread $(shell pkg-config --cflags libmongocxx)
 CPPFLAGS := $(CFLAGS)
 IS_READER0 := false
 ifeq "$(shell hostname)" "reader0"

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -75,7 +75,7 @@ fs::path MongoLog::OutputDirectory(struct tm*) {
 
 int MongoLog::RotateLogFile() {
   if (fOutfile.is_open()) fOutfile.close();
-  auto [today, std::ignore] = Now();
+  auto [today, ms] = Now();
   auto filename = LogFilePath(&today);
   std::cout<<"Logging to " << filename << std::endl;
   auto pp = filename.parent_path();
@@ -88,7 +88,7 @@ int MongoLog::RotateLogFile() {
     std::cout << "Could not rotate logfile!\n";
     return -1;
   }
-  fOutfile << FormatTime(&today) << " [INIT]: logfile initialized: commit " << REDAX_BUILD_COMMIT << "\n";
+  fOutfile << FormatTime(&today, ms) << " [INIT]: logfile initialized: commit " << REDAX_BUILD_COMMIT << "\n";
   fToday = Today(&today);
   if (fDeleteAfterDays == 0) return 0;
   std::vector<int> days_per_month = {31,28,31,30,31,30,31,31,30,31,30,31};
@@ -105,10 +105,10 @@ int MongoLog::RotateLogFile() {
   }
   auto p = LogFileName(&last_week);
   if (std::experimental::filesystem::exists(p)) {
-    fOutfile << FormatTime(&today) << " [INIT]: Deleting " << p << '\n';
+    fOutfile << FormatTime(&today, ms) << " [INIT]: Deleting " << p << '\n';
     std::experimental::filesystem::remove(p);
   } else {
-    fOutfile << FormatTime(&today) << " [INIT]: No older logfile to delete :(\n";
+    fOutfile << FormatTime(&today, ms) << " [INIT]: No older logfile to delete :(\n";
   }
   return 0;
 }

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -51,8 +51,8 @@ void MongoLog::Flusher() {
 
 std::string MongoLog::FormatTime(struct tm* date, int ms) {
   std::string out("YYYY-MM-DD HH:mm:SS.SSS");
-  // this step is technically illegal: "Modifying the character array accessed through the const overload of data has undefined behavior." but I can't c++20 and it worked when tested, so :shrug:
-  sprintf((char*)out.data(), "%04i-%02i-%02i %02i:%02i:%02i.%03i", date->tm_year+1900,
+  // this is kinda awkward but we can't use c++20's time-formatting gubbins so :(
+  sprintf(out.data(), "%04i-%02i-%02i %02i:%02i:%02i.%03i", date->tm_year+1900,
       date->tm_mon+1, date->tm_mday, date->tm_hour, date->tm_min, date->tm_sec, ms);
   return out;
 }

--- a/MongoLog.hh
+++ b/MongoLog.hh
@@ -15,6 +15,7 @@
 #include <thread>
 #include <experimental/filesystem>
 #include <memory>
+#include <tuple>
 
 #include <mongocxx/pool.hpp>
 #include <mongocxx/client.hpp>
@@ -71,9 +72,10 @@ public:
   void SetRunId(const int runid) {fRunId = runid;}
 
 protected:
+  std::tuple<struct tm, int> Now();
   void Flusher();
   int RotateLogFile();
-  virtual std::string FormatTime(struct tm*);
+  virtual std::string FormatTime(struct tm*, int);
   virtual int Today(struct tm*);
   virtual std::string LogFileName(struct tm*);
   virtual std::experimental::filesystem::path OutputDirectory(struct tm*);

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -43,6 +43,8 @@ def main():
     sleep_period = int(config['DEFAULT']['PollFrequency'])
     sh = SignalHandler()
 
+    logger.info('Dispatcher starting up')
+
     while(sh.event.is_set() == False):
         # Get most recent check-in from all connected hosts
         if MongoConnector.GetUpdate():

--- a/main.cc
+++ b/main.cc
@@ -20,12 +20,8 @@
 #include <mongocxx/client.hpp>
 #include <mongocxx/pool.hpp>
 
-#ifndef REDAX_BUILD_BRANCH
-#define REDAX_BUILD_BRANCH "unknown"
-#endif
-
-#ifndef REDAX_BUILD_DATE
-#define REDAX_BUILD_DATE "unknown"
+#ifndef REDAX_BUILD_COMMIT
+#define REDAX_BUILD_COMMIT "unknown"
 #endif
 
 std::atomic_bool b_run = true;
@@ -74,7 +70,7 @@ int PrintUsage() {
 }
 
 int PrintVersion() {
-  std::cout << "Redax branch " << REDAX_BUILD_BRANCH << " built on " << REDAX_BUILD_DATE << "\n";
+  std::cout << "Redax commit " << REDAX_BUILD_COMMIT << "\n";
   return 0;
 }
 


### PR DESCRIPTION
While millisecond-precise logs aren't a panacea for tracking synchronization-based issues, they sure help. This PR kludges this in in a mildly ugly way, because we can't build against c++20 yet.