### PR TITLE
Mutex timing info

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -257,9 +257,9 @@ void DAQController::ReadData(int link){
   if (mutex_wait_times.size() > 0) {
     std::sort(mutex_wait_times.begin(), mutex_wait_times.end());
     fLog->Entry(MongoLog::Local, "RO thread %i mutex report: min %i max %i mean %i median %i num %i",
-        link, mutex_wait_time.front(), mutex_wait_time.back(),
-        std::accumulate(mutex_wait_time.begin(), mutex_wait_time.end(), 0l)/mutex_wait_time.size(),
-        mutex_wait_time[mutex_wait_time.size()/2], mutex_wait_time.size());
+        link, mutex_wait_times.front(), mutex_wait_times.back(),
+        std::accumulate(mutex_wait_times.begin(), mutex_wait_times.end(), 0l)/mutex_wait_times.size(),
+        mutex_wait_time[mutex_wait_times.size()/2], mutex_wait_times.size());
   }
   fRunning[link] = false;
   fLog->Entry(MongoLog::Local, "RO thread %i returning", link);

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -12,7 +12,6 @@
 #include <chrono>
 #include <cmath>
 #include <numeric>
-#include <fstream>
 
 #include <bsoncxx/builder/stream/document.hpp>
 
@@ -256,10 +255,11 @@ void DAQController::ReadData(int link){
     std::this_thread::sleep_for(sleep_time);
   } // while run
   if (mutex_wait_times.size() > 0) {
-    std::ofstream fout("/live_data/test/mutex_"+fHostname+"_ro"+std::to_string(link),
-        std::ios::binary);
-    fout.write((char*)mutex_wait_times.data(), sizeof(mutex_wait_times[0])*mutex_wait_times.size());
-    fout.close();
+    std::sort(mutex_wait_times.begin(), mutex_wait_times.end());
+    fLog->Entry(MongoLog::Local, "RO thread %i mutex report: min %i max %i mean %i median %i num %i",
+        link, mutex_wait_time.front(), mutex_wait_time.back(),
+        std::accumulate(mutex_wait_time.begin(), mutex_wait_time.end(), 0l)/mutex_wait_time.size(),
+        mutex_wait_time[mutex_wait_time.size()/2], mutex_wait_time.size());
   }
   fRunning[link] = false;
   fLog->Entry(MongoLog::Local, "RO thread %i returning", link);

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -259,7 +259,7 @@ void DAQController::ReadData(int link){
     fLog->Entry(MongoLog::Local, "RO thread %i mutex report: min %i max %i mean %i median %i num %i",
         link, mutex_wait_times.front(), mutex_wait_times.back(),
         std::accumulate(mutex_wait_times.begin(), mutex_wait_times.end(), 0l)/mutex_wait_times.size(),
-        mutex_wait_time[mutex_wait_times.size()/2], mutex_wait_times.size());
+        mutex_wait_times[mutex_wait_times.size()/2], mutex_wait_times.size());
   }
   fRunning[link] = false;
   fLog->Entry(MongoLog::Local, "RO thread %i returning", link);

--- a/StraxFormatter.cc
+++ b/StraxFormatter.cc
@@ -68,9 +68,10 @@ StraxFormatter::~StraxFormatter(){
   std::stringstream ss;
   ss << std::hex << fThreadId;
   if (fMutexWaitTime.size() > 0) {
-    std::ofstream fout("/live_data/test/mutex_"+fFullHostname, std::ios::binary);
-    fout.write((char*)fMutexWaitTime.data(), sizeof(fMutexWaitTime[0])*fMutexWaitTime.size());
-    fout.close();
+    fLog->Entry(MongoLog::Local, "Thread %lx mutex report: min %i max %i mean %i median %i num %i",
+        fThreadId, fMutexWaitTime.front(), fMutexWaitTime.back(),
+        std::accumulate(fMutexWaitTime.begin(), fMutexWaitTime.end(), 0l)/fMutexWaitTime.size(),
+        fMutexWaitTime[fMutexWaitTime.size()/2], fMutexWaitTime.size());
   }
 }
 
@@ -304,6 +305,7 @@ void StraxFormatter::Process() {
   }
   if (fBytesProcessed > 0)
     End();
+  if (fMutexWaitTime.size() > 0) std::sort(fMutexWaitTime.begin(), fMutexWaitTime.end());
 }
 
 // Can tune here as needed, these are defaults from the LZ4 examples

--- a/StraxFormatter.cc
+++ b/StraxFormatter.cc
@@ -65,8 +65,6 @@ StraxFormatter::StraxFormatter(std::shared_ptr<Options>& opts, std::shared_ptr<M
 }
 
 StraxFormatter::~StraxFormatter(){
-  std::stringstream ss;
-  ss << std::hex << fThreadId;
   if (fMutexWaitTime.size() > 0) {
     fLog->Entry(MongoLog::Local, "Thread %lx mutex report: min %i max %i mean %i median %i num %i",
         fThreadId, fMutexWaitTime.front(), fMutexWaitTime.back(),

--- a/StraxFormatter.cc
+++ b/StraxFormatter.cc
@@ -67,9 +67,11 @@ StraxFormatter::StraxFormatter(std::shared_ptr<Options>& opts, std::shared_ptr<M
 StraxFormatter::~StraxFormatter(){
   std::stringstream ss;
   ss << std::hex << fThreadId;
-  std::ofstream fout("/live_data/test/mutex_"+fFullHostname, std::ios::binary);
-  fout.write((char*)fMutexWaitTime.data(), sizeof(int)*fMutexWaitTime.size());
-  fout.close();
+  if (fMutexWaitTime.size() > 0) {
+    std::ofstream fout("/live_data/test/mutex_"+fFullHostname, std::ios::binary);
+    fout.write((char*)fMutexWaitTime.data(), sizeof(fMutexWaitTime[0])*fMutexWaitTime.size());
+    fout.close();
+  }
 }
 
 void StraxFormatter::Close(std::map<int,int>& ret){

--- a/StraxFormatter.cc
+++ b/StraxFormatter.cc
@@ -47,7 +47,6 @@ StraxFormatter::StraxFormatter(std::shared_ptr<Options>& opts, std::shared_ptr<M
 
   fEmptyVerified = 0;
   fLog = log;
-  fMutexWaitTime = fMutexLocks = 0;
 
   fBufferNumChunks = fOptions->GetInt("strax_buffer_num_chunks", 2);
   fWarnIfChunkOlderThan = fOptions->GetInt("strax_chunk_phase_limit", 2);

--- a/StraxFormatter.hh
+++ b/StraxFormatter.hh
@@ -15,6 +15,7 @@
 #include <list>
 #include <memory>
 #include <string_view>
+#include <chrono>
 
 class Options;
 class MongoLog;
@@ -109,6 +110,7 @@ private:
   std::condition_variable fCV;
   std::mutex fBufferMutex;
   std::list<std::unique_ptr<data_packet>> fBuffer;
+  long fMutexWaitTime, fMutexLocks;
 };
 
 #endif

--- a/StraxFormatter.hh
+++ b/StraxFormatter.hh
@@ -110,7 +110,7 @@ private:
   std::condition_variable fCV;
   std::mutex fBufferMutex;
   std::list<std::unique_ptr<data_packet>> fBuffer;
-  long fMutexWaitTime, fMutexLocks;
+  std::vector<int> fMutexWaitTime;
 };
 
 #endif


### PR DESCRIPTION
Tracks the amount of time necessary for the readout threads to lock the specified StraxFormatter's buffer mutex. If this is a "slow" operation it likely contributes to deadtime issues during very high rates.