### PR TITLE
Add timeout to arming sequence

### DIFF
--- a/dispatcher/config.ini
+++ b/dispatcher/config.ini
@@ -35,6 +35,9 @@ StopCommandTimeout = 30
 RetryReset = 3
 # Min time between Stop-Arm and Arm-Start commands
 TimeBetweenCommands = 6
+#Maximum number of allowed timeouts during the arming sequence before doing something
+MaxTimeout=10
+
 
 # Time between reader and CC start (can be float)
 # THIS IS AN IMPORTANT VALUE, DON'T CHANGE IT UNLESS YOU KNOW WHAT YOU'RE DOING


### PR DESCRIPTION
This pull request:
* Adds timeout counter to the arming sequence. If it times out too often, max set in config, invoke the hypervisor's tactical nuclear option