### PR TITLE
Moves the dispatcher's local queue into memory

### DIFF
--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -78,7 +78,7 @@ class MongoConnect():
 
         # a place to buffer commands temporarily
         self.command_queue = []
-        self.q_mutex = threading.Mutex()
+        self.q_mutex = threading.Lock()
 
         self.digi_type = 'V17' if not testing else 'f17'
         self.cc_type = 'V2718' if not testing else 'f2718'

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -571,7 +571,7 @@ class MongoConnect():
                 docs[1]['acknowledged'] = {h:0 for h in docs[1]['host']}
                 docs[1]['createdAt'] += datetime.timedelta(seconds=delay)
             with self.q_mutex:
-                self.collections['command_queue'] += docs
+                self.command_queue += docs
         except Exception as e:
             self.log.debug(f'SendCommand ran into {type(e)}, {e})')
             return -1


### PR DESCRIPTION
Rather than the database. The original idea was that this would help ensure continuity around dispatcher crashes/restarts, but I don't think this is a good idea/necessary anymore.