### PR TITLE
Dispatcher armed and operational

### DIFF
--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -277,7 +277,7 @@ class DAQController():
                 self.hypervisor.tactical_nuclear_option()
                 self.last_nuke = now()
             else:
-                self.log.debug(f'Nuclear timeout at {int(dt)}/{self.hv_nuke_timeout}')
+                self.log.debug(f'Nuclear timeout at {int(dt)}/{self.hv_nuclear_timeout}')
             return
 
         if command is None: # not specified, we figure out it here
@@ -313,7 +313,7 @@ class DAQController():
                             self.hypervisor.tactical_nuclear_option()
                             self.last_nuke = now()
                         else:
-                            self.log.debug(f'Nuclear timeout at {int(dt)}/{self.hv_nuke_timeout}')
+                            self.log.debug(f'Nuclear timeout at {int(dt)}/{self.hv_nuclear_timeout}')
                     self.error_stop_count[detector] = 0
                 else:
                     self.control_detector(detector=detector, command='stop')

--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -3,7 +3,6 @@ import json
 import enum
 import pytz
 from daqnt import DAQ_STATUS
-from .MongoConnect import NO_NEW_RUN
 
 """
 DAQ Controller Brain Class
@@ -20,7 +19,6 @@ resetting of runs (the ~hourly stop/start) during normal operations.
 
 def now():
     return datetime.datetime.now(pytz.utc)
-    #return datetime.datetime.utcnow() # wrong?
 
 class DAQController():
 
@@ -49,6 +47,9 @@ class DAQController():
                 k.lower() : int(config['%sCommandTimeout' % k])
                 for k in ['Arm','Start','Stop']}
         self.stop_retries = int(config['RetryReset'])
+
+        self.hv_nuclear_timeout = int(config['HypervisorNuclearTimeout'])
+        self.last_nuke = now()
 
         self.log = log
         self.time_between_commands = int(config['TimeBetweenCommands'])
@@ -148,7 +149,7 @@ class DAQController():
 
                 # Maybe the detector is IDLE, we should arm a run
                 elif latest_status[det]['status'] == DAQ_STATUS.IDLE:
-                    self.log.info(f"The {det} is in idle, sending arm command")
+                    self.log.info(f"The {det} is idle, sending arm command")
                     self.control_detector(command='arm', detector=det)
 
                 # Deal separately with the TIMEOUT and ERROR statuses, by stopping the detector if needed
@@ -228,7 +229,7 @@ class DAQController():
                 #Reset arming timeout counter 
                 self.missed_arm_cycles[detector]=0
             else: # stop
-                readers, cc = self.mongo.get_hosts_for_mode(ls[detector]['mode'])
+                readers, cc = self.mongo.get_hosts_for_mode(ls[detector]['mode'], detector)
                 hosts = (cc, readers)
                 if force or ls[detector]['status'] not in [DAQ_STATUS.RUNNING]:
                     delay = 0
@@ -246,7 +247,7 @@ class DAQController():
             if command == 'start' and self.mongo.insert_run_doc(detector):
                 # db having a moment
                 return
-            if (command == 'stop' and ls[detector]['number'] != NO_NEW_RUN and
+            if (command == 'stop' and ls[detector]['number'] != -1 and
                     self.mongo.set_stop_time(ls[detector]['number'], detector, force)):
                 # db having a moment
                 return
@@ -270,7 +271,13 @@ class DAQController():
         #First check how often we have been timing out, if it happened to often
         # something bad happened and we start from scratch again
         if self.missed_arm_cycles[detector]>self.max_arm_cycles and detector=='tpc':
-            self.hypervisor.tactical_nuclear_option()
+            if (dt := (now()-self.last_nuke).total_seconds()) > self.hv_nuclear_timeout:
+                self.log.critical('There\'s only one way to be sure')
+                self.control_detector(detector='tpc', command='stop', force=True)
+                self.hypervisor.tactical_nuclear_option()
+                self.last_nuke = now()
+            else:
+                self.log.debug(f'Nuclear timeout at {int(dt)}/{self.hv_nuke_timeout}')
             return
 
         if command is None: # not specified, we figure out it here
@@ -300,7 +307,13 @@ class DAQController():
                                         "STOP_TIMEOUT")
                     # also invoke the nuclear option
                     if detector == 'tpc':
-                        self.hypervisor.tactical_nuclear_option()
+                        if (dt := (now()-self.last_nuke).total_seconds()) > self.hv_nuclear_timeout:
+                            self.control_detector(detector='tpc', command='stop', force=True)
+                            self.log.critical('There\'s only one way to be sure')
+                            self.hypervisor.tactical_nuclear_option()
+                            self.last_nuke = now()
+                        else:
+                            self.log.debug(f'Nuclear timeout at {int(dt)}/{self.hv_nuke_timeout}')
                     self.error_stop_count[detector] = 0
                 else:
                     self.control_detector(detector=detector, command='stop')

--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -89,6 +89,9 @@ class MongoConnect():
         # Which control keys do we look for?
         self.control_keys = config['ControlKeys'].split()
 
+        # How often can we restart hosts?
+        self.hypervisor_host_restart_timeout = int(config['HypervisorHostRestartTimeout'])
+
         self.digi_type = 'V17' if not testing else 'f17'
         self.cc_type = 'V2718' if not testing else 'f2718'
 
@@ -110,14 +113,17 @@ class MongoConnect():
         self.latest_status = {}
         self.host_config = {}
         self.dc = daq_config
+        self.hv_timeout_fix = {}
         for detector in self.dc:
             self.latest_status[detector] = {'readers': {}, 'controller': {}}
             for reader in self.dc[detector]['readers']:
                 self.latest_status[detector]['readers'][reader] = {}
                 self.host_config[reader] = detector
+                self.hv_timeout_fix[reader] = now()
             for controller in self.dc[detector]['controller']:
                 self.latest_status[detector]['controller'][controller] = {}
                 self.host_config[controller] = detector
+                self.hv_timeout_fix[controller] = now()
 
         self.log = log
         self.run = True
@@ -153,12 +159,12 @@ class MongoConnect():
                     dc[detector]['controller'][host] = doc
         except Exception as e:
             self.log.error(f'Got error while getting update: {type(e)}: {e}')
-            return True
+            return None
 
         self.latest_status = dc
 
         # Now compute aggregate status
-        return self.aggregate_status() is not None
+        return self.latest_status if self.aggregate_status() is None else None
 
     def clear_error_timeouts(self):
         self.error_sent = {}
@@ -212,7 +218,7 @@ class MongoConnect():
                 try:
                     status = DAQ_STATUS(doc['status'])
                     if self.is_timeout(doc, now_time):
-                        self.status = DAQ_STATUS.TIMEOUT
+                        status = DAQ_STATUS.TIMEOUT
                 except Exception as e:
                     self.log.debug(f'Ran into {type(e)}, daq is in timeout. {e}')
                     status = DAQ_STATUS.UNKNOWN
@@ -294,12 +300,17 @@ class MongoConnect():
         ret = False
         if dt > self.timeout:
             self.log.debug(f'{host} last reported {int(dt)} sec ago')
-            ret |= True
+            ret = ret or True
         if has_ackd is not None and t - has_ackd > self.timeout_take_action:
             self.log.debug(f'{host} hasn\'t ackd a command from {int(t-has_ackd)} sec ago')
             if self.host_config[host] == 'tpc':
-                self.hypervisor.handle_timeout(host)
-            ret |= True
+                dt = (now() - self.hv_timeout_fix[host]).total_seconds()
+                if dt > self.hypervisor_host_restart_timeout:
+                    self.hypervisor.handle_timeout(host)
+                    self.hv_timeout_fix[host] = now()
+                else:
+                    self.log.debug(f'Not restarting {host}, timeout at {int(dt)}')
+            ret = ret or True
         return ret
 
     def get_wanted_state(self):
@@ -353,8 +364,8 @@ class MongoConnect():
         - case E: tpc unlinked, mv and nv linked
         We will check the compatibility of the linked mode for a pair of detectors per time.
         """
-        ret = {'tpc': {'controller': list(self.dc['tpc']['controller'].keys()),
-                       'readers': list(self.dc['tpc']['readers'].keys()),
+        ret = {'tpc': {'controller': self.dc['tpc']['controller'][:],
+                       'readers': self.dc['tpc']['readers'][:],
                        'detectors': ['tpc']}}
         mv = self.dc['muon_veto']
         nv = self.dc['neutron_veto']
@@ -366,29 +377,29 @@ class MongoConnect():
         # tpc and muon_veto linked mode
         if tpc_mv:
             # case A or C
-            ret['tpc']['controller'] += list(mv['controller'].keys())
-            ret['tpc']['readers'] += list(mv['readers'].keys())
+            ret['tpc']['controller'] += mv['controller']
+            ret['tpc']['readers'] += mv['readers']
             ret['tpc']['detectors'] += ['muon_veto']
         else:
             # case B or E
-            ret['muon_veto'] = {'controller': list(mv['controller'].keys()),
-                    'readers': list(mv['readers'].keys()),
-                    'detectors': ['muon_veto']}
+            ret['muon_veto'] = {'controller': mv['controller'][:],
+                                'readers': mv['readers'][:],
+                                'detectors': ['muon_veto']}
         if tpc_nv:
             # case A or D
-            ret['tpc']['controller'] += list(nv['controller'].keys())
-            ret['tpc']['readers'] += list(nv['readers'].keys())
+            ret['tpc']['controller'] += nv['controller'][:]
+            ret['tpc']['readers'] += nv['readers'][:]
             ret['tpc']['detectors'] += ['neutron_veto']
         elif mv_nv and not tpc_mv:
             # case E
-            ret['muon_veto']['controller'] += list(nv['controller'].keys())
-            ret['muon_veto']['readers'] += list(nv['readers'].keys())
+            ret['muon_veto']['controller'] += nv['controller'][:]
+            ret['muon_veto']['readers'] += nv['readers'][:]
             ret['muon_veto']['detectors'] += ['neutron_veto']
         else:
             # case B or C
-            ret['neutron_veto'] = {'controller': list(nv['controller'].keys()),
-                    'readers': list(nv['readers'].keys()),
-                    'detectors': ['neutron_veto']}
+            ret['neutron_veto'] = {'controller': nv['controller'][:],
+                                   'readers': nv['readers'][:],
+                                   'detectors': ['neutron_veto']}
 
         # convert the host lists to dics for later
         for det in list(ret.keys()):
@@ -427,16 +438,18 @@ class MongoConnect():
             self.log.error("Got a %s exception in doc pulling: %s" % (type(e), e))
         return None
 
-    def get_hosts_for_mode(self, mode):
+    def get_hosts_for_mode(self, mode, detector=None):
         """
         Get the nodes we need from the run mode
         """
-        if mode is None:
-            self.log.debug("Run mode is none?")
-            return [], []
-        doc = self.get_run_mode(mode)
-        if doc is None:
-            self.log.debug("No run mode?")
+        if mode is None or mode == 'none':
+            if detector is None:
+                self.log.error('No mode, no detector? wtf?')
+                return [], []
+            return (list(self.latest_status[detector]['readers'].keys()),
+                    list(self.latest_status[detector]['controller'].keys()))
+        if (doc := self.get_run_mode(mode)) is None:
+            self.log.error('How did this happen?')
             return [], []
         cc = []
         hostlist = []
@@ -592,7 +605,7 @@ class MongoConnect():
         sort = [('_id', 1)]
         if (doc := self.collections['outgoing_commands'].find_one(q, sort=sort)) is None:
             return None
-        return doc['createdAt'].timestamp()
+        return doc['createdAt'].replace(tzinfo=pytz.utc).timestamp()
 
     def detector_ackd_command(self, detector, command):
         """
@@ -628,19 +641,22 @@ class MongoConnect():
                 "message": message,
                 "priority": self.loglevels[priority]
             })
-        except:
-            self.log.error('Database error, can\'t issue error message')
+        except Exception as e:
+            self.log.error(f'Database error, can\'t issue error message: {type(e)}, {e}')
         self.log.info("Error message from dispatcher: %s" % (message))
         return
 
     def get_run_start(self, number):
+        """
+        Returns the timezone-corrected run start time from the rundoc
+        """
         try:
             doc = self.collections['run'].find_one({"number": number}, {"start": 1})
         except Exception as e:
             self.log.error(f'Database is having a moment: {type(e)}, {e}')
             return None
         if doc is not None and 'start' in doc:
-            return doc['start']
+            return doc['start'].replace(tzinfo=pytz.utc)
         return None
 
     def insert_run_doc(self, detector):
@@ -649,7 +665,7 @@ class MongoConnect():
             self.log.error("DB having a moment")
             return -1
         # the rundoc gets the physical detectors, not the logical
-        detectors = self.goal_state[detector]['detectors']
+        detectors = self.latest_status[detector]['detectors']
 
         run_doc = {
             "number": number,

--- a/dispatcher/config.ini
+++ b/dispatcher/config.ini
@@ -34,7 +34,10 @@ StopCommandTimeout = 30
 RetryReset = 3
 # Min time between Stop-Arm and Arm-Start commands
 TimeBetweenCommands = 6
-
+# How often the HV can restart hosts
+HypervisorHostRestartTimeout = 300
+# How often we can drop nukes
+HypervisorNuclearTimeout = 1800
 
 # Time between reader and CC start (can be float)
 # THIS IS AN IMPORTANT VALUE, DON'T CHANGE IT UNLESS YOU KNOW WHAT YOU'RE DOING
@@ -91,6 +94,8 @@ StartCommandTimeout = 20
 StopCommandTimeout = 30
 RetryReset = 3
 TimeBetweenCommands = 6
+HypervisorHostRestartTimeout = 30
+HypervisorNuclearTimeout = 1800
 StartCmdDelay = 1
 StopCmdDelay = 1
 ControlKeys = active comment mode softstop stop_after


### PR DESCRIPTION
Things that work:
 - Immediate automatic restart of timing-out hosts (2 minutes downtime)
 - Nuclear option due to missed arm cycles (full test of #30/#31)
 - Timeouts for HV actions

Bugs fixed:
 - Things relating to time zones. Now, every function that returns a timestamp or date object tz-corrects before returning.
 - Some typos
 - TIMEOUT states not being propagated properly
 - `get_hosts_for_mode` doesn't work if you don't provide it a mode (obvious, but requires a workaround)

Things not tested yet:
 - Linked mode
 - Nuclear option due to dispatcher not knowing what else to do