### PR TITLE
Threadsafe logging

### DIFF
--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -162,8 +162,10 @@ int MongoLog::Entry(int priority, const std::string& message, ...){
   std::string msg(len + 1, 0);
   va_start (args, message);
   // Fill the new string we just made
-  std::vsnprintf(msg.data(), len + 1, message.c_str(), args);
+  std::vsnprintf(msg.data(), len+1, message.c_str(), args);
   va_end (args);
+  // strip the trailing \0
+  msg.pop_back();
   {
     std::unique_lock<std::mutex> lg(fMutex);
     fQueue.emplace_back(std::make_tuple(std::move(today), ms, priority, std::move(msg)));

--- a/MongoLog.hh
+++ b/MongoLog.hh
@@ -17,6 +17,7 @@
 #include <memory>
 #include <tuple>
 #include <condition_variable>
+#include <list>
 
 #include <mongocxx/pool.hpp>
 #include <mongocxx/client.hpp>
@@ -95,7 +96,7 @@ protected:
   int fDeleteAfterDays;
   int fToday;
   std::mutex fMutex;
-  std::queue<std::tuple<struct tm, int, int, std::string>> fQueue;
+  std::list<std::tuple<struct tm, int, int, std::string>> fQueue;
   std::condition_variable fCV;
   std::experimental::filesystem::path fOutputDir;
   std::thread fFlushThread;

--- a/MongoLog.hh
+++ b/MongoLog.hh
@@ -16,6 +16,7 @@
 #include <experimental/filesystem>
 #include <memory>
 #include <tuple>
+#include <condition_variable>
 
 #include <mongocxx/pool.hpp>
 #include <mongocxx/client.hpp>
@@ -80,7 +81,7 @@ protected:
   virtual std::string LogFileName(struct tm*);
   virtual std::experimental::filesystem::path OutputDirectory(struct tm*);
   virtual std::experimental::filesystem::path LogFilePath(struct tm*);
-
+  void MakeEntry(int priority, const std::string& message);
 
   std::shared_ptr<mongocxx::pool> fPool;
   mongocxx::pool::entry fClient;
@@ -94,6 +95,8 @@ protected:
   int fDeleteAfterDays;
   int fToday;
   std::mutex fMutex;
+  std::vector<std::pair<int, std::string>> fQueue;
+  std::condition_variable fCV;
   std::experimental::filesystem::path fOutputDir;
   std::thread fFlushThread;
   std::atomic_bool fFlush;

--- a/MongoLog.hh
+++ b/MongoLog.hh
@@ -69,7 +69,7 @@ public:
   const static int Local   = -1; // Write to local (file) log only
 
   virtual int Initialize() {return RotateLogFile();}
-  virtual int Entry(int priority, std::string, ...);
+  virtual int Entry(int priority, const std::string&, ...);
   void SetRunId(const int runid) {fRunId = runid;}
 
 protected:
@@ -95,7 +95,7 @@ protected:
   int fDeleteAfterDays;
   int fToday;
   std::mutex fMutex;
-  std::vector<std::pair<int, std::string>> fQueue;
+  std::queue<std::tuple<struct tm, int, int, std::string>> fQueue;
   std::condition_variable fCV;
   std::experimental::filesystem::path fOutputDir;
   std::thread fFlushThread;


### PR DESCRIPTION
The Mongo classes are not threadsafe, so the way we have handled the logging does occasionally cause segfaults when log messages are coming very quickly. This PR fixes this, by having one thread actually interact with the database and all other threads put log messages into a queue.