### PR TITLE
Caches run start time

### DIFF
--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -489,8 +489,8 @@ class MongoConnect():
                     rate[doc['_id']] = {'avg': doc['avg'], 'max': doc['max']}
                 self.collections['run'].update_one({'number': int(number)},
                                                    {'$set': {'rate': rate}})
-                if (number,) in self.run_start_cache:
-                    del self.run_start_cache[(number,)]
+                if str(number) in self.run_start_cache:
+                    del self.run_start_cache[str(number)]
             else:
                 self.log.debug('No run updated?')
         except Exception as e:
@@ -638,15 +638,15 @@ class MongoConnect():
         return
 
     def get_run_start(self, number):
-        if (number,) in self.run_start_cache:
-            return self.run_start_cache[(number,)]
+        if str(number) in self.run_start_cache:
+            return self.run_start_cache[str(number)]
         try:
             doc = self.collections['run'].find_one({"number": number}, {"start": 1})
         except Exception as e:
             self.log.error(f'Database is having a moment: {type(e)}, {e}')
             return None
         if doc is not None and 'start' in doc:
-            self.run_start_cache[(number,)] = doc['start'].replace(tzinfo=pytz.utc)
+            self.run_start_cache[str(number)] = doc['start'].replace(tzinfo=pytz.utc)
             return doc['start']
         return None
 


### PR DESCRIPTION
Because it's much more efficient than constantly hammering the RunsDB, even though it's hitting indexed fields.