### PR TITLE
Faster offloading

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -213,7 +213,7 @@ void DAQController::ReadData(int link){
   fRunning[link] = true;
   std::chrono::microseconds sleep_time(fOptions->GetInt("us_between_reads", 10));
   int c = 0;
-  const int num_threads = fProcessingThreads;
+  const int num_threads = fNProcessingThreads;
   while(fReadLoop){
     for(auto& digi : fDigitizers[link]) {
 
@@ -252,7 +252,7 @@ void DAQController::ReadData(int link){
     if (local_buffer.size() > 0) {
       fDataRate += bytes_this_loop;
       auto t_start = std::chrono::high_resolution_clock::now();
-      while (fFormatters[(++c)%num_threads]->ReceiveDataPackets(local_buffer, bytes_this_loop)) {}
+      while (fFormatters[(++c)%num_threads]->ReceiveDatapackets(local_buffer, bytes_this_loop)) {}
       auto t_end = std::chrono::high_resolution_clock::now();
       mutex_wait_times.push_back(std::chrono::duration_cast<std::chrono::nanoseconds>(
             t_end-t_start).count());

--- a/DAQController.cc
+++ b/DAQController.cc
@@ -207,12 +207,13 @@ void DAQController::ReadData(int link){
   std::list<std::unique_ptr<data_packet>> local_buffer;
   std::unique_ptr<data_packet> dp;
   std::vector<int> mutex_wait_times;
+  mutex_wait_times.reserve(1<<20);
   int words = 0;
   int bytes_this_loop(0);
   fRunning[link] = true;
   std::chrono::microseconds sleep_time(fOptions->GetInt("us_between_reads", 10));
   int c = 0;
-  const int num_threads = fNumProcessingThreads;
+  const int num_threads = fProcessingThreads;
   while(fReadLoop){
     for(auto& digi : fDigitizers[link]) {
 
@@ -250,7 +251,6 @@ void DAQController::ReadData(int link){
     } // for digi in digitizers
     if (local_buffer.size() > 0) {
       fDataRate += bytes_this_loop;
-      int selector = (fCounter++)%fNProcessingThreads;
       auto t_start = std::chrono::high_resolution_clock::now();
       while (fFormatters[(++c)%num_threads]->ReceiveDataPackets(local_buffer, bytes_this_loop)) {}
       auto t_end = std::chrono::high_resolution_clock::now();

--- a/MongoLog.cc
+++ b/MongoLog.cc
@@ -52,7 +52,7 @@ void MongoLog::Flusher() {
     fCV.wait(lk, [&]{return fQueue.size() > 0 || fFlush == false;});
     if (fQueue.size()) {
       auto [today, ms, priority, message] = std::move(fQueue.front());
-      fQueue.pop();
+      fQueue.pop_front();
       lk.unlock();
       std::stringstream msg;
       msg<<FormatTime(&today, ms)<<" ["<<fPriorities[priority+1] <<"]: "<<message<<std::endl;

--- a/StraxFormatter.cc
+++ b/StraxFormatter.cc
@@ -50,6 +50,7 @@ StraxFormatter::StraxFormatter(std::shared_ptr<Options>& opts, std::shared_ptr<M
 
   fBufferNumChunks = fOptions->GetInt("strax_buffer_num_chunks", 2);
   fWarnIfChunkOlderThan = fOptions->GetInt("strax_chunk_phase_limit", 2);
+  fMutexWaitTime.reserve(1<<20);
 
   std::string output_path = fOptions->GetString("strax_output_path", "./");
   try{
@@ -270,7 +271,7 @@ void StraxFormatter::AddFragmentToBuffer(std::string fragment, uint32_t ts, int 
 int StraxFormatter::ReceiveDatapackets(std::list<std::unique_ptr<data_packet>>& in, int bytes) {
   using namespace std::chrono;
   auto start = high_resolution_clock::now();
-  if (fBufferMutex.try_lock() {
+  if (fBufferMutex.try_lock()) {
     auto end = high_resolution_clock::now();
     fBufferCounter[in.size()]++;
     fBuffer.splice(fBuffer.end(), in);

--- a/StraxFormatter.hh
+++ b/StraxFormatter.hh
@@ -59,7 +59,7 @@ public:
   void Process();
   std::pair<int, int> GetBufferSize() {return {fInputBufferSize.load(), fOutputBufferSize.load()};}
   void GetDataPerChan(std::map<int, int>& ret);
-  void ReceiveDatapackets(std::list<std::unique_ptr<data_packet>>&, int);
+  int ReceiveDatapackets(std::list<std::unique_ptr<data_packet>>&, int);
 
 private:
   void ProcessDatapacket(std::unique_ptr<data_packet> dp);

--- a/V1724.cc
+++ b/V1724.cc
@@ -217,7 +217,8 @@ int V1724::Read(std::unique_ptr<data_packet>& outptr){
   if ((GetAcquisitionStatus() & 0x8) == 0) return 0;
   // Initialize
   int blt_words=0, nb=0, ret=-5;
-  std::list<std::pair<char32_t*, int>> xfer_buffers;
+  std::vector<std::pair<char32_t*, int>> xfer_buffers;
+  xfer_buffers.reserve(16);
 
   int count = 0;
   int alloc_words = BLT_SIZE/sizeof(char32_t)*fBLTSafety;


### PR DESCRIPTION
Occasionally it takes a readout thread many milliseconds to offload a pack of datapackets to a processing threads. This is a long time in terms of how long a digitizer's buffer is, so if we can reduce the amount of time it takes before a lockable mutex is found, we should be able to keep this number much lower.

Also, trojaning in this PR, pre-allocating some vectors, and replacing a `std::list` with a `std::vector`.