### PR TITLE
Change source type documenting

### DIFF
--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -691,7 +691,7 @@ class MongoConnect():
         # If there's a source add the source. Also add the complete ini file.
         cfg = self.get_run_mode(self.goal_state[detector]['mode'])
         if cfg is not None and 'source' in cfg.keys():
-            run_doc['source'] = str(cfg['source'])
+            run_doc['source'] = cfg['source']
         run_doc['daq_config'] = cfg
 
         # If the user started the run with a comment add that too


### PR DESCRIPTION
Rarther than
![afbeelding](https://user-images.githubusercontent.com/22295914/115950044-2d4fe000-a4d9-11eb-96bc-d082a1d6933f.png)
I think this was the desired format
```python
{'source': {'type': 'none'}}
```
