### PR TITLE
Mongo logger now also logs locally

### DIFF
--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -637,7 +637,7 @@ class MongoConnect():
 
     def log_error(self, message, priority, etype):
         #Start by logging the error localy
-        self.log.INFO(f"{message}")
+        self.log.info(message)
         # Note that etype allows you to define timeouts.
         nowtime = now()
         if ( (etype in self.error_sent and self.error_sent[etype] is not None) and


### PR DESCRIPTION
The mongo logger used to just log to the mongo database and not locally. Now it also logs the message locally.
This also solves the problem of not enough logging in check_timeouts, this will make all possiblities have a locally logged message