### PR TITLE
Stores missing channels in rundoc

### DIFF
--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -504,8 +504,17 @@ class MongoConnect():
                                 'max': {'$max': '$rate'}}}
                     ]):
                     rate[doc['_id']] = {'avg': doc['avg'], 'max': doc['max']}
+                channels = set()
+                if 'tpc' in detectors:
+                    # figure out which channels weren't running
+                    readers = list(self.latest_status[detectors]['readers'].keys())
+                    for doc in self.collections['node_status'].find({'host': {'$in': readers}, 'number': int(number)}):
+                        channels |= set(map(int, doc['channels'].keys()))
+                updates = {'rate': rate}
+                if len(channels):
+                    update['no_data_from'] = sorted(list(set(range(494)) - channels))
                 self.collections['run'].update_one({'number': int(number)},
-                                                   {'$set': {'rate': rate}})
+                                                   {'$set': updates})
                 if str(number) in self.run_start_cache:
                     del self.run_start_cache[str(number)]
             else:


### PR DESCRIPTION
Sometimes, for reasons, a channel decides it isn't going to return any data one run. It's really convenient if we store all channels from which no data was seen, rather than manually digging through the raw data. Most of the time this list is really short, so finding an extra member is easy.