### PR TITLE
Maybe fix for nuclear timeout issues

### DIFF
--- a/dispatcher/DAQController.py
+++ b/dispatcher/DAQController.py
@@ -277,8 +277,9 @@ class DAQController():
                 self.hypervisor.tactical_nuclear_option()
                 self.last_nuke = now()
             else:
+                #self.control_detector(detector=detector, command='stop')
                 self.log.debug(f'Nuclear timeout at {int(dt)}/{self.hv_nuclear_timeout}')
-            return
+            #return
 
         if command is None: # not specified, we figure out it here
             command_times = [(cmd,doc[detector]) for cmd,doc in self.last_command.items()]
@@ -313,6 +314,7 @@ class DAQController():
                             self.hypervisor.tactical_nuclear_option()
                             self.last_nuke = now()
                         else:
+                            self.control_detector(detector=detector, command='stop')
                             self.log.debug(f'Nuclear timeout at {int(dt)}/{self.hv_nuclear_timeout}')
                     self.error_stop_count[detector] = 0
                 else:


### PR DESCRIPTION
Often, especially while the fallout is still falling, the dispatcher doesn't properly recover, instead trying to deploy the nukes again but being limited by the timeout. I'm still not 100% sure why we end up in this situation, but I think this PR will help prevent them by making it much more likely that a STOP will be issued (which is often what is needed to fix the situation)