### PR TITLE
Implementation for #21

### DIFF
--- a/StraxFormatter.cc
+++ b/StraxFormatter.cc
@@ -134,6 +134,12 @@ void StraxFormatter::ProcessDatapacket(std::unique_ptr<data_packet> dp){
         fLog->Entry(MongoLog::Warning, "Missed an event from %i at idx %x/%x (%x)",
             dp->digi->bid(), std::distance(dp->buff.begin(), it), dp->buff.size(), *it);
         missed = false;
+        // this happens quite rarely, the chance of overwriting ourselves is vanishing
+        // but it's nice to be able to know why we missed an event
+        std::string filename = std::to_string(fOptions->GetInt("number", -1)) + "_missed";
+        std::ofstream fout(filename, std::ios::out | std::ios::binary);
+        fout.write((char*)dp->buff.data(), dp->buff.size()*sizeof(dp->buff[0]));
+        fout.close();
       }
       it++;
     }

--- a/V1724.cc
+++ b/V1724.cc
@@ -123,11 +123,6 @@ bool V1724::EnsureStopped(int ntries, int tsleep){
 uint32_t V1724::GetAcquisitionStatus(){
   return ReadRegister(fAqStatusRegister);
 }
-int V1724::ResetClocks() {
-  fRolloverCounter = 0;
-  fLastClock = 0;
-  return WriteRegister(fClearRegister, 0x1);
-}
 int V1724::CheckErrors(){
   auto pll = ReadRegister(fBoardFailStatRegister);
   auto ros = ReadRegister(fReadoutStatusRegister);

--- a/V1724.hh
+++ b/V1724.hh
@@ -52,7 +52,6 @@ class V1724{
   virtual bool EnsureStopped(int ntries, int sleep);
   virtual int CheckErrors();
   virtual uint32_t GetAcquisitionStatus();
-  virtual int ResetClocks();
 
 protected:
   // Some values for base classes to override 


### PR DESCRIPTION
If we miss an event, we dump that data packet's buffer to disk (`.`) so we can inspect later if this was an off-by-one or something.