### PR TITLE
Adds rate filter to dispatcher

### DIFF
--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -84,6 +84,9 @@ class MongoConnect(object):
         self.digi_type = 'V17' if not testing else 'f17'
         self.cc_type = 'V2718' if not testing else 'f2718'
 
+        self.reader_rate_filter = int(config['reader_rate_filter_length'])
+        self.suspicious_rate_ratio = float(config['suspicious_rate_ratio'])
+
         # We will store the latest status from each reader here
         # Format:
         # {
@@ -103,9 +106,11 @@ class MongoConnect(object):
         self.host_config = {}
         self.dc = daq_config
         self.hv_timeout_fix = {}
+        self.reader_rate = {}
         for detector in self.dc:
             self.latest_status[detector] = {'readers': {}, 'controller': {}}
             for reader in self.dc[detector]['readers']:
+                self.reader_rate[reader] = []
                 self.latest_status[detector]['readers'][reader] = {}
                 self.host_config[reader] = detector
                 self.hv_timeout_fix[reader] = now()
@@ -195,11 +200,24 @@ class MongoConnect(object):
             modes = []
             run_nums = []
             for doc in self.latest_status[detector]['readers'].values():
-                phys_det = self.host_config[doc['host']]
+                host = doc['host']
+                phys_det = self.host_config[host]
                 try:
                     aggstat[phys_det]['rate'] += doc['rate']
                     aggstat[phys_det]['buff'] += doc['buffer_size']
                     aggstat[phys_det]['pll_unlocks'] += doc.get('pll', 0)
+                    # we also track the ratio between the 'old rate' (the bytes coming from the digitizer)
+                    # and the 'new rate" (the bytes going to disk), because when these aren't the same
+                    # it usually means some shenanigans are going on and we should restart the run
+                    rate_frac = doc['rate_old']/doc['rate'] if doc['rate'] > 0 else 1
+                    self.reader_rate[host].append(rate_frac)
+                    if len(self.reader_rate[host]) > self.reader_rate_filter:
+                        self.reader_rate[host] = self.reader_rate[host][-self.reader_rate_filter:]
+                    if (len(self.reader_rate[host]) == self.reader_rate_filter and 
+                        sorted(self.reader_rate[host])[self.reader_rate_filter//2] > self.suspicious_rate_ratio
+                        and phys_det == 'tpc'):
+                        # just overwrite it here, simplest this way
+                        doc['status'] = DAQ_STATUS.ERROR
                 except Exception as e:
                     # This is not really important but it's nice if we have it
                     self.logger.debug(f'Rate calculation ran into {type(e)}: {e}')

--- a/dispatcher/config.ini
+++ b/dispatcher/config.ini
@@ -46,6 +46,12 @@ StartCmdDelay = 1
 # Time between CC and reader stop (less important, also can be float)
 StopCmdDelay = 5
 
+# Reader rate filter feature
+# Take the median rate of this many values
+reader_rate_filter_length = 9
+# if it's above this value, shenanigans are happening
+suspicious_rate_ratio = 1.5
+
 # these are the control keys to look for
 ControlKeys = active comment mode softstop stop_after
 
@@ -98,6 +104,8 @@ HypervisorHostRestartTimeout = 30
 HypervisorNuclearTimeout = 1800
 StartCmdDelay = 1
 StopCmdDelay = 1
+reader_rate_filter_length = 2
+suspicious_rate_ratio = 2
 ControlKeys = active comment mode softstop stop_after
 MasterDAQConfig = {
         "tpc": {"controller": ["reader4_controller_0"], "readers": ["reader4_reader_0"]},


### PR DESCRIPTION
Sometimes shenanigans happen and the only way we can see it is in the ratio between the `rate_old` and `rate` fields in the status docs. When shenanigans happen we should restart the run because otherwise the shenanigans become nefarious.
![image](https://user-images.githubusercontent.com/10812861/135407787-57c90b07-039e-4f3c-bc1c-4bce691a5645.png)
