### PR TITLE
Track rollovers with channel timestamps rather than event timestamps

### DIFF
--- a/V1724.cc
+++ b/V1724.cc
@@ -144,8 +144,11 @@ int V1724::Reset() {
 std::tuple<uint32_t, long> V1724::GetClockInfo(std::u32string_view sv) {
   auto it = sv.begin();
   do {
-    if ((*it)>>28 == 0xA) {
-      uint32_t ht = *(it+3)&0x7FFFFFFF;
+    if ((*it)>>28 == 0xA && ((*it)&0x7FFFFFFF) > 6) {
+      // we skip the event header and go for the first channel timestamp
+      // it doesn't really matter which channel it is, they can't be so different
+      // as to completely fool the logic
+      uint32_t ht = *(it+5)&0x7FFFFFFF;
       return {ht, GetClockCounter(ht)};
     }
   } while (++it < sv.end());

--- a/V1724_MV.cc
+++ b/V1724_MV.cc
@@ -11,6 +11,18 @@ V1724(log, opts, bid, address) {
 
 V1724_MV::~V1724_MV(){}
 
+std::tuple<uint32_t, long> V1724::GetClockInfo(std::u32string_view sv) {
+  auto it = sv.begin();
+  do {
+    if ((*it)>>28 == 0xA) {
+      uint32_t ht = *(it+3)&0x7FFFFFFF;
+      return {ht, GetClockCounter(ht)};
+    }
+  } while (++it < sv.end());
+  fLog->Entry(MongoLog::Message, "No clock info for %i?", fBID);
+  return {0xFFFFFFFF, -1};
+}
+
 std::tuple<int64_t, int, uint16_t, std::u32string_view> 
 V1724_MV::UnpackChannelHeader(std::u32string_view sv, long rollovers,
     uint32_t header_time, uint32_t event_time, int event_words, int n_channels) {

--- a/V1724_MV.hh
+++ b/V1724_MV.hh
@@ -12,6 +12,7 @@ public:
   virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int);
 
 protected:
+  std::tuple<uint32_t, long> V1724::GetClockInfo(std::u32string_view);
 };
 
 #endif


### PR DESCRIPTION
Because shenanigans sometimes happen. The unmodified V1724 routine gets copied into the MV subclass so it continues to function as expected.