### PR TITLE
Input delay compensation

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -552,7 +552,7 @@ int DAQController::FitBaselines(std::vector<std::shared_ptr<V1724>> &digis,
             if (!(channel_mask & (1 << ch))) continue;
             std::u32string_view wf;
             std::tie(std::ignore, words, std::ignore, wf) = d->UnpackChannelHeader(sv,
-                0, 0, 0, words, channels_in_event);
+                0, 0, 0, words, channels_in_event, ch);
             vector<int> hist(0x4000, 0);
             for (auto w : wf) {
               val0 = w&0x3FFF;

--- a/StraxFormatter.cc
+++ b/StraxFormatter.cc
@@ -197,7 +197,7 @@ int StraxFormatter::ProcessChannel(std::u32string_view buff, int words_in_event,
   int n_channels = std::bitset<max_channels>(channel_mask).count();
   // returns {timestamp (ns), words this channel, baseline, waveform}
   auto [timestamp, channel_words, baseline_ch, wf] = dp->digi->UnpackChannelHeader(
-      buff, dp->clock_counter, dp->header_time, event_time, words_in_event, n_channels);
+      buff, dp->clock_counter, dp->header_time, event_time, words_in_event, n_channels, channel);
 
   uint32_t samples_in_pulse = wf.size()*sizeof(char32_t)/sizeof(uint16_t);
   uint16_t sw = dp->digi->SampleWidth();

--- a/V1724.cc
+++ b/V1724.cc
@@ -43,7 +43,7 @@ V1724::V1724(std::shared_ptr<MongoLog>& log, std::shared_ptr<Options>& opts, int
   // there's a more elegant way to do this, but I'm not going to write it
   fClockPeriod = std::chrono::nanoseconds((1l<<31)*fClockCycle);
   fArtificialDeadtimeChannel = 790;
-  fDefaultDelay = 0xA * 2 * fSampleWdith; // see register document
+  fDefaultDelay = 0xA * 2 * fSampleWidth; // see register document
 }
 
 V1724::~V1724(){
@@ -190,7 +190,7 @@ int V1724::WriteRegister(unsigned int reg, unsigned int value){
   write+=value;
   int ret = 0;
   if (reg == fInputDelayRegister)
-    fDelayPerCh.assign(fNChannels, 2*fSampleWdith*value);
+    fDelayPerCh.assign(fNChannels, 2*fSampleWidth*value);
   else if ((reg & fInputDelayChRegister) == fInputDelayChRegister)
     fDelayPerCh[(reg>>16)&0xF] = 2*fSampleWidth*value;
   if((ret = CAENVME_WriteCycle(fBoardHandle, fBaseAddress+reg,
@@ -358,6 +358,6 @@ std::tuple<int64_t, int, uint16_t, std::u32string_view> V1724::UnpackChannelHead
   // will never be a large difference in timestamps in one data packet
   if (ch_time > 15e8 && header_time < 5e8 && rollovers != 0) rollovers--;
   else if (ch_time < 5e8 && header_time > 15e8) rollovers++;
-  return {((rollovers<<31)+ch_time)*fClockCycle - fInputDelay[ch], words, 0, sv.substr(2, words-2)};
+  return {((rollovers<<31)+ch_time)*fClockCycle - fDelayPerCh[ch], words, 0, sv.substr(2, words-2)};
 }
 

--- a/V1724.hh
+++ b/V1724.hh
@@ -36,7 +36,7 @@ class V1724{
   int SetThresholds(std::vector<uint16_t> vals);
 
   virtual std::tuple<int, int, bool, uint32_t> UnpackEventHeader(std::u32string_view);
-  virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int);
+  virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int, short);
 
   bool CheckFail(bool val=false) {bool ret = fError; fError = val; return ret;}
 
@@ -70,9 +70,12 @@ protected:
   unsigned int fReadoutStatusRegister;
   unsigned int fVMEAlignmentRegister;
   unsigned int fBoardErrRegister;
+  unsigned int fInputDelayRegister;
+  unsigned int fInputDelayChRegister;
 
   std::vector<int> fBLTalloc;
   std::map<int, int> fBLTCounter;
+  std::vector<int> fDelayPerCh;
 
   bool MonitorRegister(uint32_t reg, uint32_t mask, int ntries, int sleep, uint32_t val=1);
   virtual std::tuple<uint32_t, long> GetClockInfo(std::u32string_view);
@@ -80,6 +83,7 @@ protected:
   int fBoardHandle;
   int fBID;
   unsigned int fBaseAddress;
+  int fDefaultDelay;
 
   // Stuff for clock reset tracking
   int fRolloverCounter;

--- a/V1724_MV.cc
+++ b/V1724_MV.cc
@@ -6,14 +6,16 @@ V1724_MV::V1724_MV(std::shared_ptr<MongoLog>& log, std::shared_ptr<Options>& opt
 V1724(log, opts, bid, address) {
   // MV boards seem to have reg 0x1n80 for channel n threshold
   fChTrigRegister = 0x1080;
+  fInputDelayRegister = fInputDelayChRegister = 0xFFFFFFFF; // disabled
   fArtificialDeadtimeChannel = 791;
+  fDefaultDelay = 0;
 }
 
 V1724_MV::~V1724_MV(){}
 
 std::tuple<int64_t, int, uint16_t, std::u32string_view> 
 V1724_MV::UnpackChannelHeader(std::u32string_view sv, long rollovers,
-    uint32_t header_time, uint32_t event_time, int event_words, int n_channels) {
+    uint32_t header_time, uint32_t event_time, int event_words, int n_channels, short) {
   int words = (event_words-4)/n_channels;
   // returns {timestamp (ns), baseline, waveform}
   // More rollover logic here, because processing is multithreaded.

--- a/V1724_MV.hh
+++ b/V1724_MV.hh
@@ -9,7 +9,7 @@ public:
   V1724_MV(std::shared_ptr<MongoLog>&, std::shared_ptr<Options>&, int, unsigned);
   virtual ~V1724_MV();
 
-  virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int);
+  virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int, short);
 
 protected:
 };

--- a/V1730.cc
+++ b/V1730.cc
@@ -8,6 +8,7 @@ V1730::V1730(std::shared_ptr<MongoLog>& log, std::shared_ptr<Options>& options, 
   fSampleWidth = 2;
   fClockCycle = 2;
   fArtificialDeadtimeChannel = 792;
+  fDefaultDelay = 2*fSampleWidth*0xA; // see register document
 }
 
 V1730::~V1730(){}
@@ -21,10 +22,10 @@ std::tuple<int, int, bool, uint32_t> V1730::UnpackEventHeader(std::u32string_vie
 }
 
 std::tuple<int64_t, int, uint16_t, std::u32string_view>
-V1730::UnpackChannelHeader(std::u32string_view sv, long, uint32_t, uint32_t, int, int) {
+V1730::UnpackChannelHeader(std::u32string_view sv, long, uint32_t, uint32_t, int, int, short ch) {
   // returns {timestamp (ns), words this channel, baseline, waveform}
   int words = sv[0]&0x7FFFFF;
-  return {(long(sv[1]) | (long(sv[2]&0xFFFF)<<32))*fClockCycle,
+  return {(long(sv[1]) | (long(sv[2]&0xFFFF)<<32))*fClockCycle - fInputDelay[ch],
           words,
           (sv[2]>>16)&0x3FFF,
           sv.substr(3, words-3)};

--- a/V1730.cc
+++ b/V1730.cc
@@ -25,7 +25,7 @@ std::tuple<int64_t, int, uint16_t, std::u32string_view>
 V1730::UnpackChannelHeader(std::u32string_view sv, long, uint32_t, uint32_t, int, int, short ch) {
   // returns {timestamp (ns), words this channel, baseline, waveform}
   int words = sv[0]&0x7FFFFF;
-  return {(long(sv[1]) | (long(sv[2]&0xFFFF)<<32))*fClockCycle - fInputDelay[ch],
+  return {(long(sv[1]) | (long(sv[2]&0xFFFF)<<32))*fClockCycle - fDelayPerCh[ch],
           words,
           (sv[2]>>16)&0x3FFF,
           sv.substr(3, words-3)};

--- a/V1730.hh
+++ b/V1730.hh
@@ -10,7 +10,7 @@ public:
   virtual ~V1730();
 
   virtual std::tuple<int, int, bool, uint32_t> UnpackEventHeader(std::u32string_view);
-  virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int);
+  virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int, short);
 private:
 
 };


### PR DESCRIPTION
If you assign an input delay to a channel, it makes sense to subtract this value off before pushing data to disk. This simplifies the offline alignment of different channels that have different delays. Fixes #76 