### PR TITLE
One event per read cycle

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -552,7 +552,7 @@ int DAQController::FitBaselines(std::vector<std::shared_ptr<V1724>> &digis,
             if (!(channel_mask & (1 << ch))) continue;
             std::u32string_view wf;
             std::tie(std::ignore, words, std::ignore, wf) = d->UnpackChannelHeader(sv,
-                0, 0, 0, words, channels_in_event);
+                0, 0, 0, words, channels_in_event, ch);
             vector<int> hist(0x4000, 0);
             for (auto w : wf) {
               val0 = w&0x3FFF;

--- a/StraxFormatter.cc
+++ b/StraxFormatter.cc
@@ -197,7 +197,7 @@ int StraxFormatter::ProcessChannel(std::u32string_view buff, int words_in_event,
   int n_channels = std::bitset<max_channels>(channel_mask).count();
   // returns {timestamp (ns), words this channel, baseline, waveform}
   auto [timestamp, channel_words, baseline_ch, wf] = dp->digi->UnpackChannelHeader(
-      buff, dp->clock_counter, dp->header_time, event_time, words_in_event, n_channels);
+      buff, dp->clock_counter, dp->header_time, event_time, words_in_event, n_channels, channel);
 
   uint32_t samples_in_pulse = wf.size()*sizeof(char32_t)/sizeof(uint16_t);
   uint16_t sw = dp->digi->SampleWidth();

--- a/V1724.cc
+++ b/V1724.cc
@@ -230,15 +230,15 @@ int V1724::Read(std::unique_ptr<data_packet>& outptr){
   while ((GetAcquisitionStatus() & 0x8) != 0) {
     // how big is the event waiting for readout?
     if ((alloc_words = ReadRegister(fEventSizeRegister)) == 0xFFFFFFFF) {
-      for (auto& b : xfer_buffers) delete[] b.first;
-      return -1;
+      ret = 1;
+      break;
     }
     if (alloc_words == 0) {
       fLog->Entry(MongoLog::Message, "Zero-sized event from %i?", fBID);
       break;
     }
-    // Reserve space for this block transfer
-    thisBLT = new char32_t[alloc_words];
+    // Reserve space for this block transfer. Alloc more than "necessary" because CAEN driver
+    thisBLT = new char32_t[int(alloc_words * fBufferSafety)];
     request_bytes = alloc_words * sizeof(char32_t);
 
     ret = CAENVME_FIFOBLTReadCycle(fBoardHandle, fBaseAddress, thisBLT,
@@ -248,14 +248,12 @@ int V1724::Read(std::unique_ptr<data_packet>& outptr){
 		  "Board %i read error after %i reads: (%i) and transferred %i bytes this read",
 		  fBID, xfer_buffers.size(), ret, nb);
 
-      // Delete all reserved data and fail
       delete[] thisBLT;
-      for (auto& b : xfer_buffers) delete[] b.first;
-      return -1;
+      ret = 1;
     }
     if (nb > request_bytes) fLog->Entry(MongoLog::Message,
         "Board %i got %x more bytes than asked for (headroom %i)",
-        fBID, nb-request_bytes, alloc_bytes-nb);
+        fBID, nb-request_bytes, alloc_words*sizeof(char32_t)-nb);
 
     blt_words+=nb/sizeof(char32_t);
     xfer_buffers.emplace_back(std::make_pair(thisBLT, nb/sizeof(char32_t)));
@@ -264,7 +262,7 @@ int V1724::Read(std::unique_ptr<data_packet>& outptr){
   // Now we have to concatenate all this data into a single continuous buffer
   // because I'm too lazy to write a class that allows us to use fragmented
   // buffers as if they were continuous
-  if(blt_words>0){
+  if(blt_words>0 && ret != 1){
     std::u32string s;
     s.reserve(blt_words);
     for (auto& xfer : xfer_buffers) {
@@ -276,7 +274,7 @@ int V1724::Read(std::unique_ptr<data_packet>& outptr){
   }
   for (auto b : xfer_buffers) delete[] b.first;
   fTotReadTime += duration_cast<nanoseconds>(high_resolution_clock::now()-t_start);
-  return blt_words;
+  return ret == 1 ? -1 : blt_words;
 }
 
 int V1724::LoadDAC(std::vector<uint16_t> &dac_values){

--- a/V1724.cc
+++ b/V1724.cc
@@ -295,12 +295,12 @@ int V1724::ReadBlock(std::unique_ptr<data_packet>& outptr) {
 
 int V1724::ReadOneEvent(std::unique_ptr<data_packet>& outptr){
   // Initialize
-  int blt_words=0, nb=0, ret=-5;
+  int blt_words=0, nb=0, ret=-5, request_bytes=0;
+  unsigned int alloc_words;
+  std::u32string thisBLT;
   std::vector<std::u32string> xfer_buffers;
   xfer_buffers.reserve(16); // don't know if 16 is reasonable but if we have to expand this is slow and empty strings are cheap
 
-  int alloc_words, request_bytes;
-  std::u32string thisBLT;
   while ((GetAcquisitionStatus() & 0x8) != 0) {
     // how big is the event waiting for readout?
     if ((alloc_words = ReadRegister(fEventSizeRegister)) == 0xFFFFFFFF) {

--- a/V1724.cc
+++ b/V1724.cc
@@ -44,7 +44,7 @@ V1724::V1724(std::shared_ptr<MongoLog>& log, std::shared_ptr<Options>& opts, int
   // there's a more elegant way to do this, but I'm not going to write it
   fClockPeriod = std::chrono::nanoseconds((1l<<31)*fClockCycle);
   fArtificialDeadtimeChannel = 790;
-  fDefaultDelay = 0xA * 2 * fSampleWdith; // see register document
+  fDefaultDelay = 0xA * 2 * fSampleWidth; // see register document
 }
 
 V1724::~V1724(){
@@ -191,7 +191,7 @@ int V1724::WriteRegister(unsigned int reg, unsigned int value){
   write+=value;
   int ret = 0;
   if (reg == fInputDelayRegister)
-    fDelayPerCh.assign(fNChannels, 2*fSampleWdith*value);
+    fDelayPerCh.assign(fNChannels, 2*fSampleWidth*value);
   else if ((reg & fInputDelayChRegister) == fInputDelayChRegister)
     fDelayPerCh[(reg>>16)&0xF] = 2*fSampleWidth*value;
   if((ret = CAENVME_WriteCycle(fBoardHandle, fBaseAddress+reg,
@@ -220,7 +220,6 @@ unsigned int V1724::ReadRegister(unsigned int reg){
 int V1724::Read(std::unique_ptr<data_packet>& outptr){
   using namespace std::chrono;
   auto t_start = high_resolution_clock::now();
-  if  return 0;
   // Initialize
   int blt_words=0, nb=0, ret=-5;
   std::vector<std::pair<char32_t*, int>> xfer_buffers;
@@ -353,6 +352,6 @@ std::tuple<int64_t, int, uint16_t, std::u32string_view> V1724::UnpackChannelHead
   // will never be a large difference in timestamps in one data packet
   if (ch_time > 15e8 && header_time < 5e8 && rollovers != 0) rollovers--;
   else if (ch_time < 5e8 && header_time > 15e8) rollovers++;
-  return {((rollovers<<31)+ch_time)*fClockCycle - fInputDelay[ch], words, 0, sv.substr(2, words-2)};
+  return {((rollovers<<31)+ch_time)*fClockCycle - fDelayPerCh[ch], words, 0, sv.substr(2, words-2)};
 }
 

--- a/V1724.cc
+++ b/V1724.cc
@@ -237,7 +237,7 @@ int V1724::Read(std::unique_ptr<data_packet>& outptr){
       break;
     }
     // Reserve space for this block transfer. Alloc more than "necessary" because CAEN driver
-    thisBLT = new char32_t[int(alloc_words * fBufferSafety)];
+    thisBLT = new char32_t[int(alloc_words * fBLTSafety)];
     request_bytes = alloc_words * sizeof(char32_t);
 
     ret = CAENVME_FIFOBLTReadCycle(fBoardHandle, fBaseAddress, thisBLT,

--- a/V1724.cc
+++ b/V1724.cc
@@ -227,7 +227,7 @@ int V1724::Read(std::unique_ptr<data_packet>& outptr) {
   // function and handle everything else under the hood
   using namespace std::chrono;
   auto t_start = high_resolution_clock::now();
-  ret = fEventsPerBLT == 1 ? fReadOneEvent(outptr) : fReadBlock(outptr);
+  int ret = fEventsPerBLT == 1 ? ReadOneEvent(outptr) : ReadBlock(outptr);
   fTotReadTime += duration_cast<nanoseconds>(high_resolution_clock::now()-t_start);
   return ret;
 }

--- a/V1724.cc
+++ b/V1724.cc
@@ -31,6 +31,8 @@ V1724::V1724(std::shared_ptr<MongoLog>& log, std::shared_ptr<Options>& opts, int
   fInputDelayRegister = 0x8034;
   fInputDelayChRegister = 0x1034;
   fEventSizeRegister = 0x814C;
+  fEventsPerBLTRegister = 0xEF1C;
+  fEventsPerBLT = 2; // default to >1
   fError = false;
 
   fSampleWidth = 10;
@@ -194,6 +196,8 @@ int V1724::WriteRegister(unsigned int reg, unsigned int value){
     fDelayPerCh.assign(fNChannels, 2*fSampleWidth*value);
   else if ((reg & fInputDelayChRegister) == fInputDelayChRegister)
     fDelayPerCh[(reg>>16)&0xF] = 2*fSampleWidth*value;
+  else if (reg == fEventsPerBLTRegister)
+    fEventsPerBLT = value;
   if((ret = CAENVME_WriteCycle(fBoardHandle, fBaseAddress+reg,
 			&write,cvA32_U_DATA,cvD32)) != cvSuccess){
     fLog->Entry(MongoLog::Warning,
@@ -217,15 +221,86 @@ unsigned int V1724::ReadRegister(unsigned int reg){
   return temp;
 }
 
-int V1724::Read(std::unique_ptr<data_packet>& outptr){
+int V1724::Read(std::unique_ptr<data_packet>& outptr) {
+  // We read out quite differently if we're doing one event per BLT or if we're doing a bunch
+  // but the DAQController doesn't need to know the difference so we provide this interface
+  // function and handle everything else under the hood
   using namespace std::chrono;
   auto t_start = high_resolution_clock::now();
+  ret = fEventsPerBLT == 1 ? fReadOneEvent(outptr) : fReadBlock(outptr);
+  fTotReadTime += duration_cast<nanoseconds>(high_resolution_clock::now()-t_start);
+  return ret;
+}
+
+int V1724::ReadBlock(std::unique_ptr<data_packet>& outptr) {
+  // this function reads whatever data is currently stored in the digitizer in one go (generally)
+  if ((GetAcquisitionStatus() & 0x8) == 0) return 0;
   // Initialize
   int blt_words=0, nb=0, ret=-5;
-  std::vector<std::pair<char32_t*, int>> xfer_buffers;
+  std::vector<std::pair<std::u32string, int>> xfer_buffers;
+  xfer_buffers.reserve(2);
+
+  unsigned count = 0;
+  int alloc_bytes, request_bytes;
+  std::u32string thisBLT;
+  do{
+    // each loop allocate more memory than the last one.
+    // there's a fine line to walk between making many small allocations for full digitizers
+    // and fewer, large allocations for empty digitizers. 16 19 20 23 seem to be optimal
+    // for the readers, but this depends heavily on specific machines.
+    if (count < fBLTalloc.size()) {
+      alloc_bytes = 1 << fBLTalloc[count];
+    } else {
+      alloc_bytes = 1 << (fBLTalloc.back() + count - fBLTalloc.size() + 1);
+    }
+    // Reserve space for this block transfer
+    thisBLT = std::u32string(alloc_bytes/sizeof(char32_t), 0);
+    request_bytes = alloc_bytes/fBLTSafety;
+
+    ret = CAENVME_FIFOBLTReadCycle(fBoardHandle, fBaseAddress, thisBLT.data(),
+				     request_bytes, cvA32_U_MBLT, cvD64, &nb);
+    if( (ret != cvSuccess) && (ret != cvBusError) ){
+      fLog->Entry(MongoLog::Error,
+		  "Board %i read error after %i reads: (%i) and transferred %i bytes this read",
+		  fBID, count, ret, nb);
+
+      // Delete all reserved data and fail
+      return -1;
+    }
+    if (nb > request_bytes) fLog->Entry(MongoLog::Message,
+        "Board %i got %x more bytes than asked for (headroom %i)",
+        fBID, nb-request_bytes, alloc_bytes-nb);
+
+    count++;
+    blt_words+=nb/sizeof(char32_t);
+    xfer_buffers.emplace_back(std::make_pair(std::move(thisBLT), nb));
+
+  }while(ret != cvBusError);
+
+  if(blt_words>0){
+    std::u32string s;
+    s.reserve(std::accumulate(xfer_buffers.begin(), xfer_buffers.end(), 0, [&](int tot, auto& p){return tot + p.second;}));
+    for (auto& p : xfer_buffers)
+      s.append(p.first.data(), p.second);
+    auto [ht, cc] = GetClockInfo(s);
+    outptr = std::make_unique<data_packet>(std::move(s), ht, cc);
+  }
+  for (auto&& p : xfer_buffers) {
+    // is this necessary?
+    p.first.clear();
+    p.first.shrink_to_fit();
+  }
+  return blt_words;
+}
+
+int V1724::ReadOneEvent(std::unique_ptr<data_packet>& outptr){
+  // Initialize
+  int blt_words=0, nb=0, ret=-5;
+  std::vector<std::u32string> xfer_buffers;
+  xfer_buffers.reserve(16); // don't know if 16 is reasonable but if we have to expand this is slow and empty strings are cheap
 
   int alloc_words, request_bytes;
-  char32_t* thisBLT = nullptr;
+  std::u32string thisBLT;
   while ((GetAcquisitionStatus() & 0x8) != 0) {
     // how big is the event waiting for readout?
     if ((alloc_words = ReadRegister(fEventSizeRegister)) == 0xFFFFFFFF) {
@@ -236,18 +311,18 @@ int V1724::Read(std::unique_ptr<data_packet>& outptr){
       fLog->Entry(MongoLog::Message, "Zero-sized event from %i?", fBID);
       break;
     }
-    // Reserve space for this block transfer. Alloc more than "necessary" because CAEN driver
-    thisBLT = new char32_t[int(alloc_words * fBLTSafety)];
+    // Reserve space for this block transfer. No extra alloc because we do things one event at a time
+    thisBLT = std::u32string(alloc_words, 0);
     request_bytes = alloc_words * sizeof(char32_t);
 
-    ret = CAENVME_FIFOBLTReadCycle(fBoardHandle, fBaseAddress, thisBLT,
+    ret = CAENVME_FIFOBLTReadCycle(fBoardHandle, fBaseAddress, thisBLT.data(),
 				     request_bytes, cvA32_U_MBLT, cvD64, &nb);
     if( (ret != cvSuccess) && (ret != cvBusError) ){
       fLog->Entry(MongoLog::Error,
 		  "Board %i read error after %i reads: (%i) and transferred %i bytes this read",
 		  fBID, xfer_buffers.size(), ret, nb);
 
-      delete[] thisBLT;
+      thisBLT.clear();
       ret = 1;
     }
     if (nb > request_bytes) fLog->Entry(MongoLog::Message,
@@ -255,24 +330,29 @@ int V1724::Read(std::unique_ptr<data_packet>& outptr){
         fBID, nb-request_bytes, alloc_words*sizeof(char32_t)-nb);
 
     blt_words+=nb/sizeof(char32_t);
-    xfer_buffers.emplace_back(std::make_pair(thisBLT, nb/sizeof(char32_t)));
+    xfer_buffers.emplace_back(std::move(thisBLT));
   }
 
-  // Now we have to concatenate all this data into a single continuous buffer
-  // because I'm too lazy to write a class that allows us to use fragmented
-  // buffers as if they were continuous
   if(blt_words>0 && ret != 1){
     std::u32string s;
-    s.reserve(blt_words);
-    for (auto& xfer : xfer_buffers) {
-      s.append(xfer.first, xfer.second);
+    if (xfer_buffers.size() == 1) {
+      // shortcut if only one event to save an alloc, and you know how I feel about saving allocs
+      s == std::move(xfer_buffers.front());
+    } else {
+      // now we concatenate because we don't have a custom data structure that allows
+      // us to use a fragmented buffer.
+      s.reserve(blt_words);
+      for (auto& b : xfer_buffers)
+        s += b;
     }
-    fBLTCounter[int(std::ceil(std::log2(blt_words)))]++;
     auto [ht, cc] = GetClockInfo(s);
     outptr = std::make_unique<data_packet>(std::move(s), ht, cc);
   }
-  for (auto b : xfer_buffers) delete[] b.first;
-  fTotReadTime += duration_cast<nanoseconds>(high_resolution_clock::now()-t_start);
+  for (auto&& b : xfer_buffers) {
+    // is this necessary?
+    b.clear();
+    b.shrink_to_fit();
+  }
   return ret == 1 ? -1 : blt_words;
 }
 

--- a/V1724.cc
+++ b/V1724.cc
@@ -30,6 +30,7 @@ V1724::V1724(std::shared_ptr<MongoLog>& log, std::shared_ptr<Options>& opts, int
   fBoardErrRegister = 0xEF00;
   fInputDelayRegister = 0x8034;
   fInputDelayChRegister = 0x1034;
+  fEventSizeRegister = 0x814C;
   fError = false;
 
   fSampleWidth = 10;
@@ -219,35 +220,33 @@ unsigned int V1724::ReadRegister(unsigned int reg){
 int V1724::Read(std::unique_ptr<data_packet>& outptr){
   using namespace std::chrono;
   auto t_start = high_resolution_clock::now();
-  if ((GetAcquisitionStatus() & 0x8) == 0) return 0;
+  if  return 0;
   // Initialize
   int blt_words=0, nb=0, ret=-5;
   std::vector<std::pair<char32_t*, int>> xfer_buffers;
-  xfer_buffers.reserve(4);
 
-  unsigned count = 0;
-  int alloc_bytes, request_bytes;
+  int alloc_words, request_bytes;
   char32_t* thisBLT = nullptr;
-  do{
-    // each loop allocate more memory than the last one.
-    // there's a fine line to walk between making many small allocations for full digitizers
-    // and fewer, large allocations for empty digitizers. 16 19 20 23 seem to be optimal
-    // for the readers, but this depends heavily on specific machines.
-    if (count < fBLTalloc.size()) {
-      alloc_bytes = 1 << fBLTalloc[count];
-    } else {
-      alloc_bytes = 1 << (fBLTalloc.back() + count - fBLTalloc.size() + 1);
+  while ((GetAcquisitionStatus() & 0x8) != 0) {
+    // how big is the event waiting for readout?
+    if ((alloc_words = ReadRegister(fEventSizeRegister)) == 0xFFFFFFFF) {
+      for (auto& b : xfer_buffers) delete[] b.first;
+      return -1;
+    }
+    if (alloc_words == 0) {
+      fLog->Entry(MongoLog::Message, "Zero-sized event from %i?", fBID);
+      break;
     }
     // Reserve space for this block transfer
-    thisBLT = new char32_t[alloc_bytes/sizeof(char32_t)];
-    request_bytes = alloc_bytes/fBLTSafety;
+    thisBLT = new char32_t[alloc_words];
+    request_bytes = alloc_words * sizeof(char32_t);
 
     ret = CAENVME_FIFOBLTReadCycle(fBoardHandle, fBaseAddress, thisBLT,
 				     request_bytes, cvA32_U_MBLT, cvD64, &nb);
     if( (ret != cvSuccess) && (ret != cvBusError) ){
       fLog->Entry(MongoLog::Error,
 		  "Board %i read error after %i reads: (%i) and transferred %i bytes this read",
-		  fBID, count, ret, nb);
+		  fBID, xfer_buffers.size(), ret, nb);
 
       // Delete all reserved data and fail
       delete[] thisBLT;
@@ -258,11 +257,9 @@ int V1724::Read(std::unique_ptr<data_packet>& outptr){
         "Board %i got %x more bytes than asked for (headroom %i)",
         fBID, nb-request_bytes, alloc_bytes-nb);
 
-    count++;
     blt_words+=nb/sizeof(char32_t);
     xfer_buffers.emplace_back(std::make_pair(thisBLT, nb/sizeof(char32_t)));
-
-  }while(ret != cvBusError);
+  }
 
   // Now we have to concatenate all this data into a single continuous buffer
   // because I'm too lazy to write a class that allows us to use fragmented

--- a/V1724.hh
+++ b/V1724.hh
@@ -36,7 +36,7 @@ class V1724{
   int SetThresholds(std::vector<uint16_t> vals);
 
   virtual std::tuple<int, int, bool, uint32_t> UnpackEventHeader(std::u32string_view);
-  virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int);
+  virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int, short);
 
   bool CheckFail(bool val=false) {bool ret = fError; fError = val; return ret;}
 
@@ -70,9 +70,12 @@ protected:
   unsigned int fReadoutStatusRegister;
   unsigned int fVMEAlignmentRegister;
   unsigned int fBoardErrRegister;
+  unsigned int fInputDelayRegister;
+  unsigned int fInputDelayChRegister;
 
   std::vector<int> fBLTalloc;
   std::map<int, int> fBLTCounter;
+  std::vector<int> fDelayPerCh;
 
   bool MonitorRegister(uint32_t reg, uint32_t mask, int ntries, int sleep, uint32_t val=1);
   virtual std::tuple<uint32_t, long> GetClockInfo(std::u32string_view);
@@ -80,6 +83,7 @@ protected:
   int fBoardHandle;
   int fBID;
   unsigned int fBaseAddress;
+  int fDefaultDelay;
 
   // Stuff for clock reset tracking
   int fRolloverCounter;

--- a/V1724.hh
+++ b/V1724.hh
@@ -73,6 +73,7 @@ protected:
   unsigned int fInputDelayRegister;
   unsigned int fInputDelayChRegister;
   unsigned int fEventSizeRegister;
+  unsigned int fEventsPerBLTRegister;
 
   std::vector<int> fBLTalloc;
   std::map<int, int> fBLTCounter;
@@ -81,6 +82,8 @@ protected:
   bool MonitorRegister(uint32_t reg, uint32_t mask, int ntries, int sleep, uint32_t val=1);
   virtual std::tuple<uint32_t, long> GetClockInfo(std::u32string_view);
   virtual int GetClockCounter(uint32_t);
+  virtual int ReadOneEvent(std::unique_ptr<data_packet>&);
+  virtual int ReadBlock(std::unique_ptr<data_packet>&);
   int fBoardHandle;
   int fBID;
   unsigned int fBaseAddress;
@@ -99,6 +102,7 @@ protected:
   int fSampleWidth, fClockCycle;
   int16_t fArtificialDeadtimeChannel;
   std::chrono::nanoseconds fTotReadTime;
+  int fEventsPerBLT;
 };
 
 

--- a/V1724.hh
+++ b/V1724.hh
@@ -72,6 +72,7 @@ protected:
   unsigned int fBoardErrRegister;
   unsigned int fInputDelayRegister;
   unsigned int fInputDelayChRegister;
+  unsigned int fEventSizeRegister;
 
   std::vector<int> fBLTalloc;
   std::map<int, int> fBLTCounter;

--- a/V1724_MV.cc
+++ b/V1724_MV.cc
@@ -6,14 +6,16 @@ V1724_MV::V1724_MV(std::shared_ptr<MongoLog>& log, std::shared_ptr<Options>& opt
 V1724(log, opts, bid, address) {
   // MV boards seem to have reg 0x1n80 for channel n threshold
   fChTrigRegister = 0x1080;
+  fInputDelayRegister = fInputDelayChRegister = 0xFFFFFFFF; // disabled
   fArtificialDeadtimeChannel = 791;
+  fDefaultDelay = 0;
 }
 
 V1724_MV::~V1724_MV(){}
 
 std::tuple<int64_t, int, uint16_t, std::u32string_view> 
 V1724_MV::UnpackChannelHeader(std::u32string_view sv, long rollovers,
-    uint32_t header_time, uint32_t event_time, int event_words, int n_channels) {
+    uint32_t header_time, uint32_t event_time, int event_words, int n_channels, short) {
   int words = (event_words-4)/n_channels;
   // returns {timestamp (ns), baseline, waveform}
   // More rollover logic here, because processing is multithreaded.

--- a/V1724_MV.hh
+++ b/V1724_MV.hh
@@ -9,7 +9,7 @@ public:
   V1724_MV(std::shared_ptr<MongoLog>&, std::shared_ptr<Options>&, int, unsigned);
   virtual ~V1724_MV();
 
-  virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int);
+  virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int, short);
 
 protected:
 };

--- a/V1730.cc
+++ b/V1730.cc
@@ -8,6 +8,7 @@ V1730::V1730(std::shared_ptr<MongoLog>& log, std::shared_ptr<Options>& options, 
   fSampleWidth = 2;
   fClockCycle = 2;
   fArtificialDeadtimeChannel = 792;
+  fDefaultDelay = 2*fSampleWidth*0xA; // see register document
 }
 
 V1730::~V1730(){}
@@ -21,10 +22,10 @@ std::tuple<int, int, bool, uint32_t> V1730::UnpackEventHeader(std::u32string_vie
 }
 
 std::tuple<int64_t, int, uint16_t, std::u32string_view>
-V1730::UnpackChannelHeader(std::u32string_view sv, long, uint32_t, uint32_t, int, int) {
+V1730::UnpackChannelHeader(std::u32string_view sv, long, uint32_t, uint32_t, int, int, short ch) {
   // returns {timestamp (ns), words this channel, baseline, waveform}
   int words = sv[0]&0x7FFFFF;
-  return {(long(sv[1]) | (long(sv[2]&0xFFFF)<<32))*fClockCycle,
+  return {(long(sv[1]) | (long(sv[2]&0xFFFF)<<32))*fClockCycle - fInputDelay[ch],
           words,
           (sv[2]>>16)&0x3FFF,
           sv.substr(3, words-3)};

--- a/V1730.cc
+++ b/V1730.cc
@@ -25,7 +25,7 @@ std::tuple<int64_t, int, uint16_t, std::u32string_view>
 V1730::UnpackChannelHeader(std::u32string_view sv, long, uint32_t, uint32_t, int, int, short ch) {
   // returns {timestamp (ns), words this channel, baseline, waveform}
   int words = sv[0]&0x7FFFFF;
-  return {(long(sv[1]) | (long(sv[2]&0xFFFF)<<32))*fClockCycle - fInputDelay[ch],
+  return {(long(sv[1]) | (long(sv[2]&0xFFFF)<<32))*fClockCycle - fDelayPerCh[ch],
           words,
           (sv[2]>>16)&0x3FFF,
           sv.substr(3, words-3)};

--- a/V1730.hh
+++ b/V1730.hh
@@ -10,7 +10,7 @@ public:
   virtual ~V1730();
 
   virtual std::tuple<int, int, bool, uint32_t> UnpackEventHeader(std::u32string_view);
-  virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int);
+  virtual std::tuple<int64_t, int, uint16_t, std::u32string_view> UnpackChannelHeader(std::u32string_view, long, uint32_t, uint32_t, int, int, short);
 private:
 
 };


### PR DESCRIPTION
Rather than allocating a massive block of memory, if we read events one by one we only need to allocate just enough memory to hold it.