### PR TITLE
Tweaks to MC logic, also fixes a crash

### DIFF
--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -217,7 +217,7 @@ class MongoConnect(object):
                     self.logger.debug(f'{n} seems to have been offline for a few days')
                     modes.append('none')
                     run_nums.append(-1)
-                    status_list.append(DAQ_STATUS.UNKNOWN)
+                    statuses['none'] = DAQ_STATUS.UNKNOWN
                     continue
                 phys_det = self.host_config[doc['host']]
                 status = self.extract_status(doc, now_time)


### PR DESCRIPTION
A few tweaks to handle crashes where readers have been offline for long enough that there are no longer any status documents, and for when non-existing run modes are specified (previously, this latter crash was a feature not a bug).