### PR TITLE
Index that query

### DIFF
--- a/dispatcher/MongoConnect.py
+++ b/dispatcher/MongoConnect.py
@@ -688,7 +688,7 @@ class MongoConnect(object):
         :param host: str, the process name to check
         :returns: float, the timestamp of the last unack'd command, or None if none exist
         """
-        q = {f'acknowledged.{host}': 0}
+        q = {'host': host, f'acknowledged.{host}': 0}
         sort = [('_id', 1)]
         if (doc := self.collections['outgoing_commands'].find_one(q, sort=sort)) is None:
             self.logger.debug(f'No unack\'d commands for {host}')

--- a/dispatcher/config.ini
+++ b/dispatcher/config.ini
@@ -6,7 +6,7 @@ LogName = dispatcher
 # Poll frequency in seconds for main program loop. It makes
 # some sense to make other time-based options multiples of
 # this, though not required
-PollFrequency = 3
+PollFrequency = 4
 
 # How long since a client's last check-in until we consider
 # it to be 'timing out'


### PR DESCRIPTION
At the top of the dispatcher logic loop we get the most recent status snapshot. During the aggregation step we then make a bunch of non-indexed queries (looking for unacknowledged commands) that take a combined 2 seconds for all processes. After this, we make control decisions based on a now out-dated status snapshot. If we adjust the offending query to match one of the indexes, we should significantly reduce this deadtime which should prevent some problems.