### PR TITLE
Catch hypervisor command timeouts

### DIFF
--- a/dispatcher/hypervisor.py
+++ b/dispatcher/hypervisor.py
@@ -14,7 +14,7 @@ def date_now():
 
 
 class Hypervisor(object):
-    __version__ = '4.0.2'
+    __version__ = '4.0.3'
     def __init__(self,
                  db,
                  logger,
@@ -67,7 +67,12 @@ class Hypervisor(object):
         :returns: None
         """
         command = "ssh " + address + ' ' + cmd
-        cp = subprocess.run(command, shell=True, capture_output=True)
+        try:
+            cp = subprocess.run(command, shell=True, capture_output=True, timeout=30)
+        except subprocess.TimeoutExpired:
+            self.logger.error(f'Timeout while issuing command to {address}')
+            rets.append({'retcode': -1, 'stdout': '', 'stderr': ''})
+            return
         ret = {'retcode': cp.returncode,
                'stdout': cp.stdout.decode() if cp.stdout else '',
                'stderr': cp.stderr.decode() if cp.stderr else ''}


### PR DESCRIPTION
There's an edge case if the hypervisor issues a command that never returns, for instance if it tries to ssh to a machine for which it has no password-less key the command will sit and wait for the hypervisor to input the login password which it clearly cannot do. The entire dispatcher would then hang silently. This PR adds a timeout to hypervisor commands to prevent this from happening.