### PR TITLE
Integrating GPS start with dispatcher

### DIFF
--- a/dispatcher/config.ini
+++ b/dispatcher/config.ini
@@ -5,7 +5,8 @@ LogName = dispatcher
 
 # Poll frequency in seconds for main program loop. It makes
 # some sense to make other time-based options multiples of
-# this, though not required
+# this, though not required. Do not make this an even divisor
+# of the GPS period or you could deadlock
 PollFrequency = 4
 
 # How long since a client's last check-in until we consider
@@ -19,6 +20,11 @@ TimeoutActionThreshold = 10
 ControlDatabaseName = daq
 RunsDatabaseName = xenonnt
 RunsDatabaseCollection = runs
+
+# these detectors start in sync with the GPS
+StartWithGPS = tpc
+# period of GPS signals
+GPSPeriod = 10
 
 # Timeouts (seconds to wait until we assume it failed)
 # Give Arm command some time in case baselines noisy
@@ -42,6 +48,7 @@ HypervisorNuclearTimeout = 1800
 # Time between reader and CC start (can be float)
 # THIS IS AN IMPORTANT VALUE, DON'T CHANGE IT UNLESS YOU KNOW WHAT YOU'RE DOING
 # 20210308 - Darryl
+# 20220414 - Only meaningful for detectors not starting with GPS signals
 StartCmdDelay = 1
 # Time between CC and reader stop (less important, also can be float)
 StopCmdDelay = 5
@@ -88,6 +95,8 @@ TimeoutActionThreshold = 10
 ControlDatabaseName = test
 RunsDatabaseName = test
 RunsDatabaseCollection = runs
+StartWithGPS=
+GPSPeriod=10
 ArmCommandTimeout = 60
 MaxArmCycles=3
 StartCommandTimeout = 20

--- a/dispatcher/dispatcher.py
+++ b/dispatcher/dispatcher.py
@@ -62,6 +62,7 @@ def setup():
 
 def main(config, control_mc, logger, daq_config, vme_config, SlackBot, runs_mc, args):
     sh = daqnt.SignalHandler()
+    sleep_period = int(config['PollFrequency'])
 
     # Declare necessary classes
     hv = Hypervisor(
@@ -73,14 +74,15 @@ def main(config, control_mc, logger, daq_config, vme_config, SlackBot, runs_mc, 
         testing=args.test,
         slackbot=SlackBot,
     )
-    mc = MongoConnect(config, daq_config, logger, control_mc, runs_mc, hv, args.test)
-    dc = DAQController(config, daq_config, mc, logger, hv)
+    gps_start = config['StartWithGPS'].split()
+    gps_period = int(config['GPSPeriod')
+    mc = MongoConnect(config, daq_config, logger, control_mc, runs_mc, hv, args.test, sleep_period, gps_start, gps_period)
+    dc = DAQController(config, daq_config, mc, logger, hv, sleep_period, gps_start)
 
     # connect the triangle
     hv.mongo_connect = mc
     hv.daq_controller = dc
 
-    sleep_period = int(config['PollFrequency'])
 
     last_loop_dt = 0
 


### PR DESCRIPTION
Once we have the V1495 FW to support GPS sync starts, we also need an update to the dispatcher to support this. The new logic for starting a run for supported detectors is as follows:
- Is there a GPS sync signal expected between "now" and the next logic loop (min 1 sec)? If yes, send the start command, if no wait for the next cycle.
- Once the start command has been issued, wait until the GPS signal has been logged and then pull it from the db, storing that in the rundoc as the start time (additionally in a new `gps_start` field with extra precision)

There's probably something I'm missing here, but I think this is a decent start and we'll need something to test with.