### PR TITLE
Cache channel map

### DIFF
--- a/DAQController.cc
+++ b/DAQController.cc
@@ -267,7 +267,7 @@ int DAQController::OpenThreads(){
   fProcessingThreads.reserve(fNProcessingThreads);
   for(int i=0; i<fNProcessingThreads; i++){
     try {
-      fFormatters.emplace_back(std::make_unique<StraxFormatter>(fOptions, fLog));
+      fFormatters.emplace_back(std::make_unique<StraxFormatter>(fOptions, fLog, fDigitizers));
       fProcessingThreads.emplace_back(&StraxFormatter::Process, fFormatters.back().get());
     } catch(const std::exception& e) {
       fLog->Entry(MongoLog::Warning, "Error opening processing threads: %s",

--- a/DAXHelpers.hh
+++ b/DAXHelpers.hh
@@ -14,11 +14,24 @@ public:
   DAXHelpers(){};
   ~DAXHelpers(){};
 
-static unsigned int StringToHex(std::string str){
+static unsigned int StringToHexOld(std::string str){
+  // This function takes ~360ns to run
     std::stringstream ss(str);
     u_int32_t result;
     return ss >> std::hex >> result ? result : 0;
 };
+
+static unsigned int StringToHex(const std::string& str) {
+  // this function takes ~12ns to run
+  uint32_t result = 0;
+  int i = 0;
+  for (auto it = str.rbegin(); it != str.rend(); ++it) {
+    bool is_letter = *it & 0x40; // see ascii
+    int val = (!is_letter)*(*it-'0') + is_letter*(9+(*it & 0xF)); // branchless is 2x faster
+    result += (val << 4*i++); // nibble by nibble
+  }
+  return result;
+}
 
   const static int Idle    = 0;
   const static int Arming  = 1;

--- a/Options.cc
+++ b/Options.cc
@@ -308,7 +308,7 @@ int16_t Options::GetChannel(int bid, int cid){
     return bson_options["channels"][boardstring][cid].get_int32().value;
   }
   catch(std::exception& e){
-    fLog->Entry(MongoLog::Error, "Failed to look up board %i ch %i", bid, cid);
+    fLog->Entry(MongoLog::Local, "Failed to look up board %i ch %i", bid, cid);
     return -1;
   }
 }

--- a/StraxFormatter.cc
+++ b/StraxFormatter.cc
@@ -278,11 +278,14 @@ void StraxFormatter::AddFragmentToBuffer(std::string fragment, uint32_t ts, int 
 
   fOutputBufferSize += fFullFragmentSize;
 
-  if(!overlap){
+  auto chunks = {&fChunks, &fOverlaps};
+  (*chunks[overlap])[chunk_id].emplace_back(std::move(fragment));
+
+/*  if(!overlap){
     fChunks[chunk_id].emplace_back(std::move(fragment));
   } else {
     fOverlaps[chunk_id].emplace_back(std::move(fragment));
-  }
+  }*/
 }
 
 int StraxFormatter::ReceiveDatapackets(std::list<std::unique_ptr<data_packet>>& in, int bytes) {

--- a/StraxFormatter.hh
+++ b/StraxFormatter.hh
@@ -71,7 +71,6 @@ private:
   void WriteOutChunk(int);
   void WriteOutChunks();
   void End();
-  void GenerateArtificialDeadtime(int64_t, const std::shared_ptr<V1724>&);
   void AddFragmentToBuffer(std::string, uint32_t, int);
   std::vector<std::string> GetChunkNames(int);
 
@@ -89,10 +88,10 @@ private:
   int fFullFragmentSize;
   int fBufferNumChunks;
   int fWarnIfChunkOlderThan;
+  int fRunNumber;
   unsigned fChunkNameLength;
   int64_t fFullChunkLength;
   std::string fOutputPath, fHostname, fFullHostname;
-  std::shared_ptr<Options> fOptions;
   std::shared_ptr<MongoLog> fLog;
   std::atomic_bool fActive;
   std::map<int, std::list<std::string>> fChunks, fOverlaps;
@@ -105,6 +104,7 @@ private:
   std::map<int, long> fBytesPerChunk;
   std::atomic_int fInputBufferSize, fOutputBufferSize;
   long fBytesProcessed;
+  std::map<int, std::vector<int>> fChannelMap;
 
   double fProcTimeDP, fProcTimeEv, fProcTimeCh, fCompTime;
   std::thread::id fThreadId;

--- a/StraxFormatter.hh
+++ b/StraxFormatter.hh
@@ -52,7 +52,7 @@ class StraxFormatter{
   */
 
 public:
-  StraxFormatter(std::shared_ptr<Options>&, std::shared_ptr<MongoLog>&);
+  StraxFormatter(std::shared_ptr<Options>&, std::shared_ptr<MongoLog>&, const std::map<int, std::vector<std::shared_ptr<V1724>>>&);
   ~StraxFormatter();
 
   void Close(std::map<int,int>& ret);

--- a/V1724.cc
+++ b/V1724.cc
@@ -334,9 +334,10 @@ std::tuple<int64_t, int, uint16_t, std::u32string_view> V1724::UnpackChannelHead
   // More rollover logic here, because channels are independent and the
   // processing is multithreaded. We leverage the fact that readout windows are
   // short and polled frequently compared to the rollover timescale, so there
-  // will never be a large difference in timestamps in one data packet
-  if (ch_time > 15e8 && header_time < 5e8 && rollovers != 0) rollovers--;
-  else if (ch_time < 5e8 && header_time > 15e8) rollovers++;
+  // will never be a large difference in timestamps in one data packet.
+  // Allegedly
+  rollovers -= 1*(ch_time > 15e8 && header_time < 5e8 && rollovers != 0); // header rolled while channel hasn't
+  rollovers += 1*(ch_time < 5e8 && header_time > 15e8); // channel rolled while header hasn't
   return {((rollovers<<31)+ch_time)*fClockCycle - fDelayPerCh[ch] - fPreTrigPerCh[ch], words, 0, sv.substr(2, words-2)};
 }
 


### PR DESCRIPTION
Rather than hit the full Options document every time we need to look up one channel, the StraxFormatters now cache this locally.

Also optimized `DAXHelpers::StringToHex`, now runs ~30x faster.