### PR TITLE
Update hypervisor to work for nuclear timeout

### DIFF
--- a/dispatcher/hypervisor.py
+++ b/dispatcher/hypervisor.py
@@ -408,7 +408,7 @@ class Hypervisor(object):
         ok, not_ok = [], []
         physical_status = self.mongo_connect.physical_status
         for phys_det, statuses in physical_status.items():
-            if self.mongo_connect.combine_statuses(statuses) in [daqnt.DAQ_STATUS.TIMEOUT]:
+            if self.mongo_connect.combine_statuses(statuses) not in [daqnt.DAQ_STATUS.RUNNING, daqnt.DAQ_STATUS.ARMED]:
                 not_ok.append(phys_det)
             else:
                 ok.append(phys_det)


### PR DESCRIPTION
We never managed to enter in the tactic nuclear because it was only looking for timeouts. Now we say: it not armed or running, do nuclear ( that means, power cycle the crates )